### PR TITLE
doc: do not pass `tag` as parameter to `trace_off()` in example

### DIFF
--- a/ADOL-C/doc/adolc-manual.tex
+++ b/ADOL-C/doc/adolc-manual.tex
@@ -4616,7 +4616,7 @@ yprime[0] = -sin(y[2]) + 1e8*y[2]*(1-1/y[0]);
 yprime[1] = -10*y[0] + 3e7*y[2]*(1-y[1]);
 yprime[2] = -yprime[0] - yprime[1];
 yprime >>= pyprime;                   // mark and pass dependents
-trace_off(tag);
+trace_off();
 }                                     // end tracerhs
 \end{verbatim}
 The Jacobian of the right-hand side has large


### PR DESCRIPTION
It does not look like it is intended to write the trace to a file here.