### PR TITLE
Improve const correctness of drivers

### DIFF
--- a/ADOL-C/include/adolc/drivers/drivers.h
+++ b/ADOL-C/include/adolc/drivers/drivers.h
@@ -27,7 +27,7 @@ BEGIN_C_DECLS
 /*--------------------------------------------------------------------------*/
 /*                                                                 function */
 /* function(tag, m, n, x[n], y[m])                                          */
-ADOLC_DLL_EXPORT int function(short,int,int,double*,double*);
+ADOLC_DLL_EXPORT int function(short,int,int,const double*,double*);
 ADOLC_DLL_EXPORT fint function_(fint*,fint*,fint*,fdouble*,fdouble*);
 
 /*--------------------------------------------------------------------------*/
@@ -52,21 +52,21 @@ ADOLC_DLL_EXPORT fint large_jacobian_(fint*,fint*,fint*,fint*,fdouble*,fdouble*,
 /*--------------------------------------------------------------------------*/
 /*                                                         vector_jacobian  */
 /* vec_jac(tag, m, n, repeat, x[n], u[m], v[n])                             */
-ADOLC_DLL_EXPORT int vec_jac(short,int,int,int,double*,double*,double*);
+ADOLC_DLL_EXPORT int vec_jac(short,int,int,int,const double*,double*,double*);
 ADOLC_DLL_EXPORT fint vec_jac_(fint*,fint*,fint*,fint*,
                                fdouble*,fdouble*,fdouble*);
 
 /*--------------------------------------------------------------------------*/
 /*                                                          jacobian_vector */
 /* jac_vec(tag, m, n, x[n], v[n], u[m]);                                    */
-ADOLC_DLL_EXPORT int jac_vec(short,int,int,double*,double*,double*);
+ADOLC_DLL_EXPORT int jac_vec(short,int,int,const double*,const double*,double*);
 ADOLC_DLL_EXPORT fint jac_vec_(fint*,fint*,fint*,fdouble*,fdouble*,fdouble*);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                  hessian */
 /* hessian(tag, n, x[n], lower triangle of H[n][n])                         */
 /* uses Hessian-vector product                                              */
-ADOLC_DLL_EXPORT int hessian(short,int,double*,double**);
+ADOLC_DLL_EXPORT int hessian(short,int,const double*,double**);
 ADOLC_DLL_EXPORT fint hessian_(fint*,fint*,fdouble*,fdouble*);
 
 /*--------------------------------------------------------------------------*/
@@ -79,21 +79,21 @@ ADOLC_DLL_EXPORT fint hessian2_(fint*,fint*,fdouble*,fdouble*);
 /*--------------------------------------------------------------------------*/
 /*                                                           hessian_vector */
 /* hess_vec(tag, n, x[n], v[n], w[n])                                       */
-ADOLC_DLL_EXPORT int hess_vec(short,int,double*,double*,double*);
+ADOLC_DLL_EXPORT int hess_vec(short,int,const double*,const double*,double*);
 ADOLC_DLL_EXPORT fint hess_vec_(fint*,fint*,fdouble*,fdouble*,fdouble*);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           hessian_matrix */
 /* hess_mat(tag, n, q, x[n], V[n][q], W[n][q])                              */
-ADOLC_DLL_EXPORT int hess_mat(short,int,int,double*,double**,double**);
+ADOLC_DLL_EXPORT int hess_mat(short,int,int,const double*,const double**,double**);
 ADOLC_DLL_EXPORT fint hess_mat_(fint*,fint*,fint*,
                                 fdouble*,fdouble**,fdouble**);
 
 /*--------------------------------------------------------------------------*/
 /*                                                  lagrange_hessian_vector */
 /* lagra_hess_vec(tag, m, n, x[n], v[n], u[m], w[n])                        */
-ADOLC_DLL_EXPORT int lagra_hess_vec(short,int,int,double*,
-                                    double*,double*,double*);
+ADOLC_DLL_EXPORT int lagra_hess_vec(short,int,int,const double*,
+                                    const double*,const double*,double*);
 ADOLC_DLL_EXPORT fint lagra_hess_vec_(fint*,fint*,fint*,
                                       fdouble*,fdouble*,fdouble*,fdouble*);
 

--- a/ADOL-C/include/adolc/interfaces.h
+++ b/ADOL-C/include/adolc/interfaces.h
@@ -199,12 +199,12 @@ ADOLC_DLL_EXPORT int zos_forward_partx(short,int,int,int*,double**,double*);
 /* fos_forward(tag, m, n, keep, x[n], X[n], y[m], Y[m])                     */
 /* (defined in uni5_for.mc)                                                 */
 ADOLC_DLL_EXPORT int fos_forward(
-    short,int,int,int,const double*,double*,double*,double*);
+    short,int,int,int,const double*,const double*,double*,double*);
 
 /* fos_forward_nk(tag,m,n,x[n],X[n],y[m],Y[m])                              */
 /* (no keep, defined in uni5_for.c, but not supported in ADOL-C 1.8)        */
 ADOLC_DLL_EXPORT int fos_forward_nk(
-    short,int,int,const double*,double*,double*,double*);
+    short,int,int,const double*,const double*,double*,double*);
 
 /* fos_forward_partx(tag, m, n, ndim[n], x[n][][2], y[m][2])                */
 /* (based on fos_forward)                                                   */
@@ -359,7 +359,7 @@ ADOLC_DLL_EXPORT fint fos_reverse_(fint*,fint*,fint*,fdouble*,fdouble*);
 /*                                                                      HOS */
 /*  hos_reverse(tag, m, n, d, u[m], Z[n][d+1])                              */
 /* (defined  in ho_rev.mc)                                                  */
-ADOLC_DLL_EXPORT int hos_reverse(short,int,int,int,double*,double**);
+ADOLC_DLL_EXPORT int hos_reverse(short,int,int,int,const double*,double**);
 
 /* now pack the arrays into vectors for Fortran calling                     */
 ADOLC_DLL_EXPORT fint hos_reverse_(fint*,fint*,fint*,fint*,fdouble*,fdouble*);

--- a/ADOL-C/src/drivers/drivers.c
+++ b/ADOL-C/src/drivers/drivers.c
@@ -30,7 +30,7 @@ BEGIN_C_DECLS
 int function(short tag,
              int m,
              int n,
-             double* argument,
+             const double* argument,
              double* result) {
     int rc= -1;
 
@@ -63,7 +63,7 @@ int vec_jac(short tag,
             int m,
             int n,
             int repeat,
-            double* argument,
+            const double* argument,
             double* lagrange,
             double* row) {
     int rc= -1;
@@ -147,8 +147,8 @@ int large_jacobian(short tag,
 int jac_vec(short tag,
             int m,
             int n,
-            double* argument,
-            double* tangent,
+            const double* argument,
+            const double* tangent,
             double* column) {
     int rc= -1;
     double *y;
@@ -166,8 +166,8 @@ int jac_vec(short tag,
 /* hess_vec(tag, n, x[n], v[n], w[n])                                       */
 int hess_vec(short tag,
              int n,
-             double *argument,
-             double *tangent,
+             const double *argument,
+             const double *tangent,
              double *result) {
     double one = 1.0;
     return lagra_hess_vec(tag,1,n,argument,tangent,&one,result);
@@ -179,8 +179,8 @@ int hess_vec(short tag,
 int hess_mat(short tag,
              int n,
              int q,
-             double *argument,
-             double **tangent,
+             const double *argument,
+             const double **tangent,
              double **result) {
     int rc;
     int i,j;
@@ -223,7 +223,7 @@ int hess_mat(short tag,
 /* uses Hessian-vector product                                              */
 int hessian(short tag,
             int n,
-            double* argument,
+            const double* argument,
             double** hess) {
     int rc= 3;
     int i,j;
@@ -297,9 +297,9 @@ int hessian2(short tag,
 int lagra_hess_vec(short tag,
                    int m,
                    int n,
-                   double *argument,
-                   double *tangent,
-                   double *lagrange,
+                   const double *argument,
+                   const double *tangent,
+                   const double *lagrange,
                    double *result) {
     int rc=-1;
     int i;

--- a/ADOL-C/src/ho_rev.c
+++ b/ADOL-C/src/ho_rev.c
@@ -267,7 +267,7 @@ int hos_reverse(short   tnum,        /* tape id */
                 int     depen,       /* consistency chk on # of deps */
                 int     indep,       /* consistency chk on # of indeps */
                 int     degre,       /* highest derivative degree  */
-                double  *lagrange,   /* range weight vector       */
+                const double  *lagrange,   /* range weight vector       */
                 double  **results)   /* matrix of coefficient vectors */
 {
     double** L = myalloc2(depen,degre+1);

--- a/ADOL-C/src/uni5_for.c
+++ b/ADOL-C/src/uni5_for.c
@@ -575,7 +575,7 @@ int  fos_forward_nk(
     int    keep,        /* flag for reverse sweep */
 #endif
     const double *basepoint,  /* independent variable values */
-    double *argument,   /* Taylor coefficients (input) */
+    const double *argument,   /* Taylor coefficients (input) */
     double *valuepoint, /* Taylor coefficients (output) */
     double *taylors)    /* matrix of coefficient vectors */
 /* the order of the indices in argument and taylors is [var][taylor] */


### PR DESCRIPTION
This changes several input arguments for driver functions to `const`. The patch only touches the functions that are documented in the freely available documentation https://www3.math.tu-berlin.de/Vorlesungen/SS06/AlgoDiff/adolc-110.pdf.

The changed parameters are documented to be input paramters. Hence declaring them const should be fine. In fact this required that some internal function arguments also had to be made `const`.

This patch leaves out the functions that are ot documented in the linked manual. It also keeps the `lagrange` argument of `vec_jac()` non-const. Changing the latter would require to modify the 4th argument of the internal `fos_reverse()` method. However, this argument is used for write access and hence the `lagrange` parameter seems to be modified in fact.

*Disclaimer:*
While I tested all changes with `make test` (which does not lead to any compiler warnings about `const`-ness issues), I have no idea about the Adol-C internals. Hence all changes-especially to the internal methods `fos_forward()`, `fos_forward_nk()`, and `hos_reverse()`-should be carefully reviewed by someone how understands the internals.