### PR TITLE
Fix wrong dllexport attribute position

### DIFF
--- a/ADOL-C/include/adolc/fixpoint.h
+++ b/ADOL-C/include/adolc/fixpoint.h
@@ -20,7 +20,7 @@
 
 BEGIN_C_DECLS
 
-int fp_iteration ( int        sub_tape_num,
+ADOLC_DLL_EXPORT int fp_iteration ( int        sub_tape_num,
                    int      (*double_F)(double*, double* ,double*, int, int),
                    int      (*adouble_F)(adouble*, adouble*, adouble*, int, int),
                    double   (*norm)(double*, int),

--- a/ADOL-C/src/fixpoint.cpp
+++ b/ADOL-C/src/fixpoint.cpp
@@ -216,7 +216,7 @@ static int fp_fos_reverse ( int dim_x, double *x_fix_bar, int dim_xu, double *xu
     return -1;
 }
 
-ADOLC_DLL_EXPORT int fp_iteration ( int        sub_tape_num,
+int fp_iteration ( int        sub_tape_num,
                    int      (*double_F)(double*, double* ,double*, int, int),
                    int      (*adouble_F)(adouble*, adouble*, adouble*, int, int),
                    double   (*norm)(double*, int),


### PR DESCRIPTION
AFAIK, this would cause a link error.