### PR TITLE
Add optimization flag for release to cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(adol-c
   DESCRIPTION "A Package for Automatic Differentiation of Algorithms Written in C/C++"
   HOMEPAGE_URL "https://github.com/coin-or/ADOL-C")
 
+set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 add_library(adolc SHARED)
 add_library(adolc::adolc ALIAS adolc)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ The complete documentation can be found in the subdirectory "doc".
 
 2. Call CMake:
 
-     `cmake -DCMAKE_INSTALL_PREFIX=/path/you/want/to/install/in path/to/adolc/sources`
+     `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/path/you/want/to/install/in path/to/adolc/sources`
 
 3. Build and install:
 
      `make`  
      `make install`  
+
 
 
 ## Local installation using the AutoTools


### PR DESCRIPTION
This PR consists of
- "O3" flag for 'CMAKE_BUILD_TYPE=Release'
- include the corresponding command to README.md

Was suggested by @juanlucasrey