### PR TITLE
Add explicit castings to remove type warnings

### DIFF
--- a/ADOL-C/src/drivers/psdrivers.c
+++ b/ADOL-C/src/drivers/psdrivers.c
@@ -143,7 +143,7 @@ int directional_active_gradient(short tag,      /* trace identifier */
       sum = 0;
       for(i=0;i<s;i++)
         {
-          sum += fabs(sigma_g[i]);
+          sum += fabs((double)sigma_g[i]);
         }
 
        if (sum == s)

--- a/ADOL-C/src/drivers/psdrivers.c
+++ b/ADOL-C/src/drivers/psdrivers.c
@@ -143,12 +143,11 @@ int directional_active_gradient(short tag,      /* trace identifier */
       sum = 0;
       for(i=0;i<s;i++)
         {
-          sum += fabs((double)sigma_g[i]);
+          sum += abs(sigma_g[i]);
         }
 
        if (sum == s)
         {
-
           zos_pl_forward(tag,1,n,keep,x,&y,z);
           fos_pl_sig_reverse(tag,1,n,s,sigma_g, &by ,g);
           done = 1;

--- a/ADOL-C/src/fo_rev.c
+++ b/ADOL-C/src/fo_rev.c
@@ -355,7 +355,7 @@ int int_reverse_safe(
 # define ADOLC_EXT_FCT_V2_U edfct2->up
 # define ADOLC_EXT_FCT_V2_Z edfct2->zp
 # define ADOLC_EXT_FCT_V2_COMPLETE \
-    fos_reverse(iArrLength,iArr,nout,nin,outsz,edfct2->up,insz,edfct2->zp,edfct2->x,edfct2->y,edfct2->context)
+    fos_reverse(iArrLength,iArr,nout,nin,(int*)outsz,edfct2->up,(int*)insz,edfct2->zp,edfct2->x,edfct2->y,edfct2->context)
 #else
 # define ADOLC_EXT_FCT_U edfct->dpp_U
 # define ADOLC_EXT_FCT_Z edfct->dpp_Z
@@ -369,7 +369,7 @@ int int_reverse_safe(
 # define ADOLC_EXT_FCT_V2_U edfct2->Up
 # define ADOLC_EXT_FCT_V2_Z edfct2->Zp
 # define ADOLC_EXT_FCT_V2_COMPLETE \
-  fov_reverse(iArrLength,iArr,nout,nin,outsz,p,edfct2->Up,insz,edfct2->Zp,edfct2->x,edfct2->y, edfct2->context)
+  fov_reverse(iArrLength,iArr,nout,nin,(int*)outsz,p,edfct2->Up,(int*)insz,edfct2->Zp,edfct2->x,edfct2->y, edfct2->context)
 #endif
 #if !defined(_INT_REV_)
     locint n, m;


### PR DESCRIPTION
Based on #65 I looked into the compilation and added explicit castings to remove type warnings.
