### PR TITLE
removing clang warning (2nd)

### DIFF
--- a/ADOL-C/src/drivers/psdrivers.c
+++ b/ADOL-C/src/drivers/psdrivers.c
@@ -143,7 +143,7 @@ int directional_active_gradient(short tag,      /* trace identifier */
       sum = 0;
       for(i=0;i<s;i++)
         {
-          sum += fabs(sigma_g[i]);
+          sum += abs(sigma_g[i]);
         }
 
        if (sum == s)


### PR DESCRIPTION
( warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value])

