### PR TITLE
Add Formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,83 @@
+# Google C/C++ Code Style settings
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# Author: Kehan Xue, kehan.xue (at) gmail.com
+
+Language: Cpp
+BasedOnStyle: Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: Align
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never  # To avoid conflict, set this Never and each if statement should include brace when coding
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterStruct: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 80
+CompactNamespaces: false
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false  # Make sure the * or & align on the left
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 2
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Left
+ReflowComments: false
+# SeparateDefinitionBlocks: Always   # Only support since clang-format 14
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++11
+TabWidth: 4
+UseTab: Never

--- a/ADOL-C/boost-test/README.md
+++ b/ADOL-C/boost-test/README.md
@@ -8,12 +8,11 @@ Instructions for compiling the test suite with cmake:
 
 1) Create the 'build' directory inside the boost-test directory (it is ignored by git).
 
-2) In 'boost-test/build' type: 'cmake ..' or 'cmake-gui ..'
+2) In 'boost-test/build' type: 'cmake .. -DADOLC_BASE=/PATH/TO/INSTALLED/ADOLC' or 'cmake-gui ..' followed by 'make'
 
 3) Cmake will search for the system installed version of BOOST. If the minimum required version is not satisfied, please enter the path where an appropriate BOOST version is installed in '3RDPARTY_BOOST_DIR'.
 
 4) ADOL-C has to be compiled with the same version of BOOST defined in 3). When using a different BOOST version than the one provided by the operating system, ADOL-C can be configured with --with-boost flag before compiling the ADOL-C sources.
 
-5) In cmake, specify ADOLC_BASE directory where ADOL-C is installed.
 
 Run the executable boost-test-adolc.

--- a/ADOL-C/boost-test/traceFixedPointScalarTests.cpp
+++ b/ADOL-C/boost-test/traceFixedPointScalarTests.cpp
@@ -41,14 +41,12 @@ static double norm(double* x, int dim)
 
 static double traceNewtonForSquareRoot(int tapeNumber, int subTapeNumber, double argument)
 {
-  trace_on(tapeNumber);
-  adouble u;
-  u <<= argument;
 
-  //ax1 = sqrt(ax1);
+  double out;
   adouble x = 2.5;  // Initial iterate
-  adouble y;
-
+  adouble y, u;
+  trace_on(tapeNumber);
+  u <<= argument;
   fp_iteration(subTapeNumber,
                iteration<double>,
                iteration<adouble>,
@@ -63,8 +61,6 @@ static double traceNewtonForSquareRoot(int tapeNumber, int subTapeNumber, double
                &y,    // [out] Final state of the iteration
                1,     // Size of the vector x_0
                1);    // Number of parameters
-
-  double out;
   y >>= out;
   trace_off();
 


### PR DESCRIPTION
Maybe its not the worst idea to have a fixed style for formatting. I added the corresponding '.clang-format' from this repo: `https://github.com/kehanXue/google-style-clang-format`. 

If you use the 'clang-format' tool in command-line, vscode, emacs or vim, the style is now automatically applied. I'm open to other styles. 