### PR TITLE
Add basic Nix Flake support and CI workflow

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,26 @@
+name: Nix Flake CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  check-and-build:
+    name: Check and Build Nix Flake
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Check Flake
+        run: nix flake check --all-systems
+
+      - name: Build Flake
+        run: nix build

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -23,4 +23,4 @@ jobs:
         run: nix flake check --all-systems
 
       - name: Build Flake
-        run: nix build
+        run: nix build --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ install_manifest.txt
 *.dylib
 *.so
 *.dll
+
+# Nix build results
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "A Package for Automatic Differentiation of Algorithms Written in C/C++ ";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { flake-utils, nixpkgs, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages = rec {
+          adolc-cmake = pkgs.stdenv.mkDerivation {
+            name = "adolc";
+            src = ./.;
+            nativeBuildInputs = [ pkgs.cmake ];
+          };
+
+          adolc-autotools = adolc-cmake.overrideAttrs (
+            _: _: {
+              nativeBuildInputs = [ pkgs.autoreconfHook ];
+            }
+          );
+
+          default = adolc-cmake;
+        };
+      }
+    );
+}


### PR DESCRIPTION
This pull request introduces **[Nix Flake](https://nixos.wiki/wiki/Flakes)** support to the project, along with a GitHub Actions CI workflow to automate the build and check process for the Nix Flake.

In this context, you can think of **[Nix](https://nixos.org/)** as a package manager, which allows us to package ADOL-C into a **[derivation](https://wiki.nixos.org/wiki/Derivations)**. Derivations have very clearly defined inputs and outputs. It is the `*.nix` files that define this relationship (in this case, just the `flake.nix`). Everything that is required to build ADOL-C is defined within `flake.nix`—for example, `blas` and `lapack`, but also tools like CMake and the compiler itself. Every dependency is recorded in the `flake.lock` file, which includes information to reproduce these dependencies down to the byte level. These inputs (the source code with CMake files, Autotools, etc., and external dependencies), plus the recipe (`flake.nix`), allow us to produce an always reproducible build of ADOL-C, independent of who builds it or on what system it is built. Nix handles downloading and running the recipe for us.

This setup not only ensures reproducibility but also enables us to go further. For example, we can run locally the tasks that would execute in the GitHub Actions workflow, without using sometimes inconsistent tools like [`act`](https://github.com/nektos/act). This means we can run the build, the tests, [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html), and [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/) all locally and be confident that when the remote action runs, it will produce the same output.

Enabling new checks is also ridiculously easy with tools like [git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/master).

## Testing It

To try this out, first visit the [Determinate Nix Installer repo](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#determinate-nix-installer) to download Nix.

Then, check out this PR locally:

```bash
git fetch origin pull/74/head:add-basic-nix-flake
```

After that, run the build:

```bash
nix build .#adolc
```

To build the Autotools version, use:

```bash
nix build .#adolc-autotools
```