### PR TITLE
Feature/improve boost test doc cmake

### DIFF
--- a/ADOL-C/boost-test/CMakeLists.txt
+++ b/ADOL-C/boost-test/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(BOOST_MIN_VERSION "1.59.0")
 set(Boost_NO_BOOST_CMAKE ON)
 
-find_package(Boost ${BOOST_MIN_VERSION} REQUIRED)
+find_package(Boost ${BOOST_MIN_VERSION} REQUIRED COMPONENTS unit_test_framework system)
 
 if(NOT Boost_FOUND)
   message(FATAL_ERROR "Fatal error: Boost (version >= 1.69.0) required.")

--- a/ADOL-C/boost-test/CMakeLists.txt
+++ b/ADOL-C/boost-test/CMakeLists.txt
@@ -69,4 +69,8 @@ set(SOURCE_FILES
     )
 add_executable(boost-test-adolc ${SOURCE_FILES})
 
-target_link_libraries(boost-test-adolc -ladolc -lboost_system -lboost_unit_test_framework)
+target_link_libraries(boost-test-adolc 
+    PRIVATE
+    ${ADOLC_LIBRARY}
+    Boost::system 
+    Boost::unit_test_framework)

--- a/ADOL-C/boost-test/README.md
+++ b/ADOL-C/boost-test/README.md
@@ -1,19 +1,22 @@
 ADOL-C offers a unit-testing capability developed using the Boost.Test library.
 There are more than 400 tests to verify the basic functionality of ADOL-C, including both traceless and trace-based adouble variants.
 
-The minimum required version of BOOST library is 1.59.0. Any older version will cause compile-time errors. 
-The BOOST library has to be compiled --with-test module, such that the library file boost_unit_test_framework is available.
+The minimum required version of BOOST library is 1.59.0. Any older version will cause compile-time errors.
+Building the ADOL-C teste requires the BOOST libraries `unit_test_framework` and `system`.
+In case you are compiling BOOST on your own, be sure to add the flags `--with-test` and `--with-system`
+to activate the corresponding modules.
 
-Instructions for compiling the test suite with cmake:
+Instructions for compiling and running the test suite with cmake:
 
-1) Create the 'build' directory inside the boost-test directory (it is ignored by git).
+1) Create the `build` directory inside the boost-test directory (it is ignored by git).
 
-2) In 'boost-test/build' type: 'cmake ..' or 'cmake-gui ..'
+2) In `boost-test/build` type: `cmake ..  -DADOLC_BASE=[location of installed ADOL-C]` or `cmake-gui ..`.
+   Remember to specify `ADOLC_BASE` manually when using `cmake-gui`.
 
-3) Cmake will search for the system installed version of BOOST. If the minimum required version is not satisfied, please enter the path where an appropriate BOOST version is installed in '3RDPARTY_BOOST_DIR'.
+3) Cmake will search for the system installed version of BOOST. If the minimum required version is not satisfied, please enter the path where an appropriate BOOST version is installed in `3RDPARTY_BOOST_DIR`.
 
-4) ADOL-C has to be compiled with the same version of BOOST defined in 3). When using a different BOOST version than the one provided by the operating system, ADOL-C can be configured with --with-boost flag before compiling the ADOL-C sources.
+4) Notice that ADOL-C has to be compiled with the same version of BOOST defined in 3). When using a different BOOST version than the one provided by the operating system, ADOL-C can be configured with `--with-boost` flag before compiling the ADOL-C sources.
 
-5) In cmake, specify ADOLC_BASE directory where ADOL-C is installed.
+5) After the Cmake configuration was successful, compile the test (e.g. using `make`).
 
-Run the executable boost-test-adolc.
+6) Run the executable `./boost-test-adolc`.


### PR DESCRIPTION
When trying to build the boost tests I stumbled upon some missing information and cmake checks, that this patch tries to fix. Disclaimer: I did not try building boost on my own with `--with-system`.