### PR TITLE
Add workflow for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,7 +40,7 @@ Checks: >
   readability-redundant-*
   
   # Optional - highly aggressive rules (uncomment if needed)
-  clang-analyzer-*,
+  #clang-analyzer-*,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,7 +40,7 @@ Checks: >
   readability-redundant-*
   
   # Optional - highly aggressive rules (uncomment if needed)
-  # clang-analyzer-*,
+  clang-analyzer-*,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,64 @@
+---
+Checks: >
+  # Modernize checks
+  modernize-*
+  # Avoid raw pointers
+  modernize-use-auto,
+  modernize-use-nullptr,
+  modernize-avoid-c-arrays,
+  modernize-make-unique,
+  modernize-make-shared,
+  modernize-smart-ptr,
+  modernize-use-override,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
+  modernize-use-bool-literals,
+  modernize-loop-convert,
+  modernize-use-emplace,
+  modernize-use-using,
+  modernize-deprecated-headers,
+  modernize-pass-by-value,
+  modernize-concat-nested-namespaces,
+
+  # Core guidelines
+  cppcoreguidelines-*,
+  cppcoreguidelines-owning-memory,
+  cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  cppcoreguidelines-pro-bounds-constant-array-index,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  cppcoreguidelines-pro-type-member-init,
+  cppcoreguidelines-no-malloc,
+  
+  # Performance and safety
+  performance-*,
+  readability-*,
+  hicpp-*,
+  bugprone-*,
+  misc-*,
+  
+  # Remove unnecessary code
+  readability-redundant-*
+  
+  # Optional - highly aggressive rules (uncomment if needed)
+  # clang-analyzer-*,
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: true
+FormatStyle: file
+CheckOptions:
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '4' # Avoid auto for short types like int, bool
+  - key: cppcoreguidelines-pro-bounds-pointer-arithmetic.Strict
+    value: 'true'
+  - key: modernize-loop-convert.IgnoreUserDefined
+    value: 'false'
+  - key: readability-function-cognitive-complexity.Threshold
+    value: '25'
+  - key: modernize-use-emplace.Hint
+    value: 'false'
+  - key: cppcoreguidelines-init-variables.Suppress
+    value: 'false'
+  - key: modernize-avoid-c-arrays.StrictMode
+    value: 'true'
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,58 @@
+on: ["push", "pull_request"]
+
+name: Test Coverage
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install lcov
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lcov
+
+    - name: Install Boost
+      shell: bash
+      run: |
+        sudo apt-get install libboost-all-dev
+
+    - name: Configure and build ADOL-C
+      run: |
+        mkdir build
+        cd build
+        cmake \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_BUILD_TYPE=TestsWithCov \
+        -S .. \
+        -B .
+        cmake --build .
+    
+    - name: Run Tests
+      run: |
+        set +e # otherwise the coverage report fails if ctest finds errors
+        ctest --test-dir build/
+        exit 0
+
+    # Capture coverage data
+    - name: Generate coverage report
+      run: |
+        cd build
+        lcov --capture --directory . --output-file coverage.info
+        lcov --remove coverage.info '/usr/*' 'boost/*' 'c++11/*' --output-file coverage.info
+        lcov --list coverage.info
+
+      # Upload coverage report to Codecov
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: build/coverage.info
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unittests
+        name: code-coverage-report
+         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,6 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build -max-warnings=10 $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build -warnings-as-errors $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
         
         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,8 @@ jobs:
         - name: Install Clang-Tidy
           run: |
            sudo apt-get update
-           sudo apt-get install -y clang-tidy
+           sudo apt-get install -y clang-tidy-14
+           ln -s /usr/bin/clang-tidy-14 /usr/bin/clang-tidy
 
         - name: Configure with CMake
           run: |
@@ -25,5 +26,6 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h') 
+            clang-tidy -p build -max-warnings=10 $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+        
         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,8 +25,8 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build $(find ADOL-C/ADOL-C/src/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
-            clang-tidy -p build $(find ADOL-C/ADOL-C/include/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
-            clang-tidy -p build $(find ADOL-C/ADOL-C/c_interface -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/src/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/include/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/c_interface -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
         
         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,6 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build -warnings-as-errors $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
         
         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,6 @@ jobs:
           run: |
            sudo apt-get update
            sudo apt-get install -y clang-tidy-14
-           ln -s /usr/bin/clang-tidy-14 /usr/bin/clang-tidy
 
         - name: Configure with CMake
           run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,29 @@
+name: Run Clang-tidy Check
+
+on:
+    push:
+      branches: [ "master" ]
+    pull_request:
+      branches: [ "master" ]
+
+jobs:
+  clang-tidy-check:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Code
+          uses: actions/checkout@v4
+        
+        - name: Install Clang-Tidy
+          run: |
+           sudo apt-get update
+           sudo apt-get install -y clang-tidy
+
+        - name: Configure with CMake
+          run: |
+            cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug
+    
+        - name: Run Clang-Tidy
+          run: |
+            clang-tidy --version  # Verify installed version
+            clang-tidy -p build $(find . -name '*.cpp' '*.c' '*.hpp' '*.h') 
+        

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,5 +25,5 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build $(find . -name '*.cpp' '*.c' '*.hpp' '*.h') 
+            clang-tidy -p build $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h') 
         

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,8 @@ jobs:
         - name: Run Clang-Tidy
           run: |
             clang-tidy --version  # Verify installed version
-            clang-tidy -p build $(find . -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/ADOL-C/src/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/ADOL-C/include/ -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
+            clang-tidy -p build $(find ADOL-C/ADOL-C/c_interface -name '*.cpp' -o -name '*.c' -o -name '*.hpp' -o -name '*.h')
         
         

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,32 +11,26 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-  
-        - name: Configure CMake ADOL-C
-          run: >  
-            cmake
-            -DCMAKE_CXX_COMPILER=g++
-            -DCMAKE_C_COMPILER=gcc
-            -DCMAKE_BUILD_TYPE=Release
-            -S ${{ github.workspace }}
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }} 
-
-        - name: Build ADOLC
-          run: |
-            make
-            make install
         
         - name: Install Boost
           shell: bash
           run: |
             sudo apt-get install libboost-all-dev
 
-        - name: Build and Run Boost-Test
-          shell: bash
+        - name: Configure and build ADOL-C
           run: |
-            cd ADOL-C/boost-test
-            mkdir build && cd build
-            cmake ../ -DADOLC_BASE=${{ github.workspace }}
-            make
-            ./boost-test-adolc
+            mkdir build
+            cd build
+            cmake \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_BUILD_TYPE=Tests \
+            -S .. \
+            -B .
+            cmake --build .
+        
+        - name: Run Tests
+          run: ctest --test-dir build/ --output-on-failure
+
+
         

--- a/ADOL-C/boost-test/CMakeLists.txt
+++ b/ADOL-C/boost-test/CMakeLists.txt
@@ -1,15 +1,7 @@
-cmake_minimum_required(VERSION 3.0)
-project(boost-test-adolc CXX)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
-## BOOST
 set(3RDPARTY_BOOST_DIR "" CACHE PATH "The directory where BOOST library is installed")
 
 if(3RDPARTY_BOOST_DIR)
   set(BOOST_ROOT ${3RDPARTY_BOOST_DIR})
-#  set(BOOST_INCLUDEDIR ${3RDPARTY_BOOST_DIR}/include)
-#  set(BOOST_LIBRARYDIR ${3RDPARTY_BOOST_DIR}/lib)
 endif()
 
 set(BOOST_MIN_VERSION "1.59.0")
@@ -19,40 +11,7 @@ find_package(Boost ${BOOST_MIN_VERSION} REQUIRED COMPONENTS unit_test_framework 
 
 if(NOT Boost_FOUND)
   message(FATAL_ERROR "Fatal error: Boost (version >= 1.69.0) required.")
-else()
-  message(STATUS "Setting up BOOST")
-  message(STATUS "Boost include: " ${Boost_INCLUDE_DIRS})
-  message(STATUS "Boost library: " ${Boost_LIBRARY_DIRS})
 endif()
-
-## ADOL-C
-set (ADOLC_BASE "" CACHE PATH "The directory where ADOL-C is installed")
-if(ADOLC_BASE)
-  message(STATUS "Setting up ADOL-C")
-
-  unset(ADOLC_INCLUDE_DIR CACHE)
-  find_path(ADOLC_INCLUDE_DIR NAMES adolc/adolc.h PATHS ${ADOLC_BASE}/include NO_DEFAULT_PATH)
-  if(NOT ADOLC_INCLUDE_DIR)
-    message(FATAL_ERROR "Fatal error: ADOL-C include directory not found, check if ADOLC_BASE path is correct")
-  endif()
-  
-  unset(ADOLC_LIBRARY CACHE)
-  find_library(ADOLC_LIBRARY NAMES adolc PATHS ${ADOLC_BASE}/lib64 ${ADOLC_BASE}/lib NO_DEFAULT_PATH)
-  if(NOT ADOLC_LIBRARY)
-    message(FATAL_ERROR "Fatal error: ADOL-C library not found, check if ADOLC_BASE path is correct")
-  endif()
-  
-  unset(ADOLC_LIBRARY_DIR CACHE)
-  get_filename_component(ADOLC_LIBRARY_DIR ${ADOLC_LIBRARY} DIRECTORY CACHE) 
-  
-  message(STATUS "ADOL-C include: " ${ADOLC_INCLUDE_DIR})
-  message(STATUS "ADOL-C library: " ${ADOLC_LIBRARY_DIR})
-else()
-  message(FATAL_ERROR "ADOLC_BASE directory has to be specified")
-endif()
-
-include_directories(${Boost_INCLUDE_DIRS} ${ADOLC_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS} ${ADOLC_LIBRARY_DIR})
 
 set(SOURCE_FILES
     adouble.cpp
@@ -68,9 +27,8 @@ set(SOURCE_FILES
     traceFixedPointScalarTests.cpp
     )
 add_executable(boost-test-adolc ${SOURCE_FILES})
-
-target_link_libraries(boost-test-adolc 
-    PRIVATE
-    ${ADOLC_LIBRARY}
+target_include_directories(boost-test-adolc PRIVATE "${ADOLC_INCLUDE_DIR}")
+target_link_libraries(boost-test-adolc PRIVATE
+    adolc
     Boost::system 
     Boost::unit_test_framework)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,32 @@ if(BUILD_INTERFACE)
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adolc)
 endif()
 
+# build the tests 
+# ------------------------------------
+if(CMAKE_BUILD_TYPE STREQUAL "Tests")
+    set(ADOLC_INCLUDE_DIR "${CMAKE_BINARY_DIR}/ADOL-C/include")
+    add_subdirectory(ADOL-C/boost-test)
+
+    enable_testing()
+    add_test(NAME boost-test-adolc
+      COMMAND boost-test-adolc)
+endif()
+
+# build the adolc and tests with coverage
+# ------------------------------------
+if(CMAKE_BUILD_TYPE STREQUAL "TestsWithCov")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g --coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g --coverage")
+
+    set(ADOLC_INCLUDE_DIR "${CMAKE_BINARY_DIR}/ADOL-C/include")
+    add_subdirectory(ADOL-C/boost-test)
+
+    enable_testing()
+    add_test(NAME boost-test-adolc
+      COMMAND boost-test-adolc)
+endif()
+
+
 # export the targets
 # ------------------
 


### PR DESCRIPTION
This PR adds a basic workflow for clang-tidy, including a first `.clang-tidy` file where the checks are specified. 