### PR TITLE
Remove the clearCurrentTape method

### DIFF
--- a/ADOL-C/src/tape_handling.cpp
+++ b/ADOL-C/src/tape_handling.cpp
@@ -563,23 +563,15 @@ static void init_lib() {
   readConfigFile();
 }
 
-static void clearCurrentTape() {
-  ADOLC_OPENMP_THREAD_NUMBER;
-  ADOLC_OPENMP_GET_THREAD_NUMBER;
-  TapeInfos *tmpTapeInfos = new TapeInfos;
-
-  ADOLC_CURRENT_TAPE_INFOS.copy(*tmpTapeInfos);
-  ADOLC_CURRENT_TAPE_INFOS_FALLBACK.copy(*tmpTapeInfos);
-  delete tmpTapeInfos;
-}
-
 /* does things like closing/removing temporary files, ... */
 void cleanUp() {
   ADOLC_OPENMP_THREAD_NUMBER;
   ADOLC_OPENMP_GET_THREAD_NUMBER;
 
+  initTapeInfos(&ADOLC_CURRENT_TAPE_INFOS);
+  initTapeInfos(&ADOLC_CURRENT_TAPE_INFOS_FALLBACK);
+
   TapeInfos **tiIter;
-  clearCurrentTape();
   while (!ADOLC_TAPE_INFOS_BUFFER.empty()) {
     tiIter = &ADOLC_TAPE_INFOS_BUFFER.back();
     ADOLC_TAPE_INFOS_BUFFER.pop_back();


### PR DESCRIPTION
What it did was zeroing out the ADOLC_CURRENT_DATE_INFOS and ADOLC_CURRENT_TAPE_INFOS_FALLBACK objects.  However, it did this in a rather convoluted way:  By creating a new object (which is zeroed because its constructor calls initTapeInfos) and then assigning that object.

However, it is much simpler to call initTapeInfos directly for ADOLC_CURRENT_DATE_INFOS(_FALLBACK), and this is what this patch does.  The clearCurrentTape method becomes obsolete and is removed.