### PR TITLE
[cmake] Add CMake option to enable boost pool support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,16 @@ set(REAL_TYPE double)
 set(ADVBRANCH "#undef ADOLC_ADVANCED_BRANCHING")
 set(ADTL_REFCNT "#undef USE_ADTL_REFCOUNTING")
 set(SPARSE_DRIVERS "#undef SPARSE_DRIVERS")
-set(USE_BOOST_POOL "#undef USE_BOOST_POOL")
+
+option(ENABLE_BOOST_POOL "Flag to activate boost-pool support" OFF)
+if(ENABLE_BOOST_POOL)
+  message(STATUS "Boost-pool support is enabled.")
+  set(USE_BOOST_POOL "#define USE_BOOST_POOL 1")
+else()
+  message(STATUS "Boost-pool support is disabled.")
+  set(USE_BOOST_POOL "#undef USE_BOOST_POOL")
+endif()
+
 
 # include subdirectories for handling of includes and source files
 # ----------------------------------------------------------------


### PR DESCRIPTION
Since the variable `USE_BOOST_POOL` is configured in CMake one could mark this as a `CACHE STRING` variable to make it user-settable. Then the user could enable boost-pool support by setting this variable. However, passing

```
cmake -DUSE_BOOST_POOL='#define USE_BOOST_POOL 1'
```

is rather user unfriendly. Furthermore a binary decision should be configured via a boolean option. Hence, this introduces a CMake option that allows to activate support via

```
cmake -DENABLE_BOOST_POOL=ON
```