### PR TITLE
Move sematics for adouble

### DIFF
--- a/ADOL-C/include/adolc/adouble.h
+++ b/ADOL-C/include/adolc/adouble.h
@@ -294,6 +294,7 @@ public:
   adouble &operator=(double);
   adouble &operator=(const badouble &);
   adouble &operator=(const adouble &);
+  adouble &operator=(adouble &&);
   adouble &operator=(const adub &);
   adouble &operator=(const pdouble &);
 

--- a/ADOL-C/include/adolc/adouble.h
+++ b/ADOL-C/include/adolc/adouble.h
@@ -275,6 +275,7 @@ protected:
 public:
   adouble(const adub &);
   adouble(const adouble &);
+  adouble(adouble &&) noexcept;
   adouble(void);
   adouble(double);
 /* adub prevents postfix operators to occur on the left

--- a/ADOL-C/include/adolc/adouble.h
+++ b/ADOL-C/include/adolc/adouble.h
@@ -107,7 +107,6 @@ public:
   void declareDependent();
   badouble &operator=(double);
   badouble &operator=(const badouble &);
-  badouble &operator=(const adub &);
   double getValue() const;
   inline double value() const { return getValue(); }
   explicit operator double();
@@ -295,7 +294,7 @@ public:
   adouble &operator=(const badouble &);
   adouble &operator=(const adouble &);
   adouble &operator=(adouble &&);
-  adouble &operator=(const adub &);
+  adouble &operator=(adub &);
   adouble &operator=(const pdouble &);
 
   inline locint loc(void) const;

--- a/ADOL-C/src/adouble.cpp
+++ b/ADOL-C/src/adouble.cpp
@@ -214,6 +214,18 @@ adouble::adouble(const adouble &a) {
 }
 
 /*--------------------------------------------------------------------------*/
+adouble::adouble(adouble &&a) noexcept {
+  // Take data from 'a'
+  location = a.loc();
+
+  // If 'a' wasn't initialized, this one isn't initialized either.
+  isInit = a.isInit;
+
+  // Make 'a' not own the data anymore
+  a.isInit = false;
+}
+
+/*--------------------------------------------------------------------------*/
 adouble::adouble(const adub &a) {
   location = next_loc();
   isInit = true;

--- a/ADOL-C/src/adouble.cpp
+++ b/ADOL-C/src/adouble.cpp
@@ -636,6 +636,26 @@ badouble &badouble::operator=(const adub &a) {
 }
 
 /*--------------------------------------------------------------------------*/
+/* r-value assignment */
+adouble &adouble::operator=(adouble &&a) {
+  // Destruct the old content of this adouble
+  if (isInit) {
+    free_loc(location);
+  }
+
+  // Set to new content
+  location = a.loc();
+
+  // If 'a' wasn't initialized, this one isn't initialized either.
+  isInit = a.isInit;
+
+  // Make sure that data is not touched when 'a' gets destructed
+  a.isInit = false;
+
+  return (*this);
+}
+
+/*--------------------------------------------------------------------------*/
 /* Assign an adouble an adub */
 /* olvo 980517 new version griewank */
 adouble &adouble::operator=(const adub &a) {


### PR DESCRIPTION
The `adub` class seems to implement what modern C++ calls 'r-values' -- temporary objects that never get a name of their own. If this is true then it should be possible to get rid of `adub` completely, and replace it by move-semantics for `adouble`.  This MR contains a few first steps into that direction.

Please test and review them thoroughly. I have not understood all the details yet. I have used the patches for a few weeks without problems, but there is one test failure testing `extdiff`. Note that verifying that the patched code still runs and produces correct results is not enough: One has to check that the patches do not lead to longer tapes (which they shouldn't).