### PR TITLE
Adds an python interface function for hess_pat

### DIFF
--- a/ADOL-C/swig/adolc-numpy-drv.i
+++ b/ADOL-C/swig/adolc-numpy-drv.i
@@ -333,6 +333,48 @@ extern "C" {
 #endif
     }
 
+    void npy_hess_pat(short t, double* x, int n1,
+                        unsigned int** rstart, int* nnz1,
+                        unsigned int** cind, int* nnz2,
+                        int option) {
+#if defined(SPARSE_DRIVERS)
+        DO_GET_DIMENSIONS
+        if (n1 != n) {
+            PyErr_Format(PyExc_ValueError,
+                         "Array lengths don't match expected dimensions"
+                         "\nExpected shapes (%d,)",n
+                );
+            return;
+        }
+        *nnz1 = n;
+
+        *start = (unsigned int*) malloc ((*nnz1 + 1) * sizeof(unsigned int));
+        unsigned int** HPp = (unsigned int**)malloc((*nnz1)*sizeof(unsigned int*));
+
+        int ret;
+        ret = hess_pat(t,n,x,HPp,option);
+
+        *nnz2 = 0;
+        for(int i = 0; i < n; i++)
+        {
+            (*start)[i] = (*nnz2);
+            *nnz2 += HPp[i][0];
+        }
+        (*start)[n] = (*nnz2);
+
+        *ind = (unsigned int*) malloc((*nnz2) * sizeof(unsigned int));
+        for(int i = 0; i < n; i++)
+        {
+            for(int j = 0; j < HPp[i][0]; j++)
+               (*ind)[(*start)[i] + j] = HPp[i][j + 1];
+        }
+        CHECKEXCEPT(ret,"hess_pat")
+#else
+        PyErr_Format(PyExc_NotImplementedError,
+                     "hess_pat() has not been compiled in the ADOL-C library");
+#endif
+    }
+
     void npy_set_param_vec(short t, int n, double* x, int n0) {
         if (n0 != n) {
             PyErr_Format(PyExc_ValueError,

--- a/ADOL-C/swig/adolc-numpy-drv.i
+++ b/ADOL-C/swig/adolc-numpy-drv.i
@@ -53,6 +53,8 @@ def as_adouble(arg):
 %rename (sparse_jac) npy_sparse_jac;
 %ignore sparse_hess;
 %rename (sparse_hess) npy_sparse_hess;
+%ignore hess_pat;
+%rename (hess_pat) npy_hess_pat;
 %ignore set_param_vec;
 %rename (set_param_vec) npy_set_param_vec;
 %ignore directional_active_gradient;
@@ -349,7 +351,7 @@ extern "C" {
         }
         *nnz1 = n;
 
-        *start = (unsigned int*) malloc ((*nnz1 + 1) * sizeof(unsigned int));
+        *rstart = (unsigned int*) malloc ((*nnz1 + 1) * sizeof(unsigned int));
         unsigned int** HPp = (unsigned int**)malloc((*nnz1)*sizeof(unsigned int*));
 
         int ret;
@@ -358,16 +360,16 @@ extern "C" {
         *nnz2 = 0;
         for(int i = 0; i < n; i++)
         {
-            (*start)[i] = (*nnz2);
+            (*rstart)[i] = (*nnz2);
             *nnz2 += HPp[i][0];
         }
-        (*start)[n] = (*nnz2);
+        (*rstart)[n] = (*nnz2);
 
-        *ind = (unsigned int*) malloc((*nnz2) * sizeof(unsigned int));
+        *cind = (unsigned int*) malloc((*nnz2) * sizeof(unsigned int));
         for(int i = 0; i < n; i++)
         {
             for(int j = 0; j < HPp[i][0]; j++)
-               (*ind)[(*start)[i] + j] = HPp[i][j + 1];
+               (*cind)[(*rstart)[i] + j] = HPp[i][j + 1];
         }
         CHECKEXCEPT(ret,"hess_pat")
 #else
@@ -466,6 +468,7 @@ extern "C" {
 %clear (double** values, int* nnz3);
 %clear (unsigned int** rind, int* nnz1);
 %clear (unsigned int** cind, int* nnz2);
+%clear (unsigned int** rstart, int* nnz1);
 %clear (short** sigma, int* nn3);
 %clear (double** Yy, int* p1, int* q1);
 %clear (double** Jj, int* p2, int* q2);

--- a/ADOL-C/swig/adolc-numpy-drv.i
+++ b/ADOL-C/swig/adolc-numpy-drv.i
@@ -89,7 +89,8 @@ def as_adouble(arg):
        {(double** values, int* nnz3)};
 %apply (unsigned int** ARGOUTVIEWM_ARRAY1, int* DIM1)
        {(unsigned int** rind, int* nnz1),
-        (unsigned int** cind, int* nnz2)};
+        (unsigned int** cind, int* nnz2),
+        (unsigned int** rstart, int* nnz1)};
 %apply (short** ARGOUTVIEWM_ARRAY1, int* DIM1) 
        {(short** sigma, int* nn3)};
 

--- a/ADOL-C/swig/adolc-numpy-drv.i
+++ b/ADOL-C/swig/adolc-numpy-drv.i
@@ -349,10 +349,10 @@ extern "C" {
                 );
             return;
         }
-        *nnz1 = n;
+        *nnz1 = n + 1;
 
-        *rstart = (unsigned int*) malloc ((*nnz1 + 1) * sizeof(unsigned int));
-        unsigned int** HPp = (unsigned int**)malloc((*nnz1)*sizeof(unsigned int*));
+        *rstart = (unsigned int*) malloc ((*nnz1) * sizeof(unsigned int));
+        unsigned int** HPp = (unsigned int**)malloc(n * sizeof(unsigned int*));
 
         int ret;
         ret = hess_pat(t,n,x,HPp,option);

--- a/ADOL-C/swig/examples/test_hess_pat.py
+++ b/ADOL-C/swig/examples/test_hess_pat.py
@@ -36,11 +36,11 @@ def initialiseAutoDiff():
 def computeHessianStructure():
    x = [0.5, 0.5, 0.0, 0.0]
    hesspat = adolc.hess_pat(0, x, 0)
-   assert(np.array_equal(hesspat[0], [0, 0, 0, 1]))
+   assert(np.array_equal(hesspat[0], [0, 0, 0, 1, 2]))
    assert(np.array_equal(hesspat[1], [3, 2]))
 
    hesspat = adolc.hess_pat(1, x, 0)
-   assert(np.array_equal(hesspat[0], [0, 2, 4, 4]))
+   assert(np.array_equal(hesspat[0], [0, 2, 4, 4, 4]))
    assert(np.array_equal(hesspat[1], [0, 1, 0, 1]))
 
 if __name__ == "__main__":

--- a/ADOL-C/swig/examples/test_hess_pat.py
+++ b/ADOL-C/swig/examples/test_hess_pat.py
@@ -36,11 +36,11 @@ def initialiseAutoDiff():
 def computeHessianStructure():
    x = [0.5, 0.5, 0.0, 0.0]
    hesspat = adolc.hess_pat(0, x, 0)
-   assert(np.array_equal(hesspat[0], [0, 0, 0, 1, 2]))
+   assert(np.array_equal(hesspat[0], [0, 0, 1, 1]))
    assert(np.array_equal(hesspat[1], [3, 2]))
 
    hesspat = adolc.hess_pat(1, x, 0)
-   assert(np.array_equal(hesspat[0], [0, 2, 4, 4, 4]))
+   assert(np.array_equal(hesspat[0], [2, 2, 0, 0]))
    assert(np.array_equal(hesspat[1], [0, 1, 0, 1]))
 
 if __name__ == "__main__":

--- a/ADOL-C/swig/examples/test_hess_pat.py
+++ b/ADOL-C/swig/examples/test_hess_pat.py
@@ -1,4 +1,5 @@
 import adolc
+import numpy as np
 
 def tapeFunction(x, rowno):
    adolc.trace_on(rowno)
@@ -18,7 +19,7 @@ def tapeFunction(x, rowno):
       ay = ax[3] * ax[2];
    elif rowno == 1:
       hold1 = (pow(ax[0],(-1.0)) + pow(ax[1],(-1.0)))
-      hold2 = pow(hold1,( -1./self.Rho ))
+      hold2 = pow(hold1,(-1.0))
 
       ay = hold2
 
@@ -41,3 +42,7 @@ def computeHessianStructure():
    hesspat = adolc.hess_pat(1, x, 0)
    assert(np.array_equal(hesspat[0], [0, 2, 4, 4]))
    assert(np.array_equal(hesspat[1], [0, 1, 0, 1]))
+
+if __name__ == "__main__":
+   initialiseAutoDiff()
+   computeHessianStructure()

--- a/ADOL-C/swig/examples/test_hess_pat.py
+++ b/ADOL-C/swig/examples/test_hess_pat.py
@@ -1,0 +1,43 @@
+import adolc
+
+def tapeFunction(x, rowno):
+   adolc.trace_on(rowno)
+   ax = adolc.as_adouble(x)
+
+   # marking the x variables as independent
+   for item in iter(ax):
+      item.declareIndependent()
+
+   L   = ax[0]
+   Inp = ax[1]
+   Out = ax[2]
+   P   = ax[3]
+
+   ay = adolc.as_adouble(0)
+   if rowno == 0:
+      ay = ax[3] * ax[2];
+   elif rowno == 1:
+      hold1 = (pow(ax[0],(-1.0)) + pow(ax[1],(-1.0)))
+      hold2 = pow(hold1,( -1./self.Rho ))
+
+      ay = hold2
+
+   ay.declareDependent()
+   adolc.trace_off()
+
+
+def initialiseAutoDiff():
+   x = [0.5, 0.5, 0.0, 0.0]
+   tapeFunction(x, 0)
+   tapeFunction(x, 1)
+
+
+def computeHessianStructure():
+   x = [0.5, 0.5, 0.0, 0.0]
+   hesspat = adolc.hess_pat(0, x, 0)
+   assert(np.array_equal(hesspat[0], [0, 0, 0, 1]))
+   assert(np.array_equal(hesspat[1], [3, 2]))
+
+   hesspat = adolc.hess_pat(1, x, 0)
+   assert(np.array_equal(hesspat[0], [0, 2, 4, 4]))
+   assert(np.array_equal(hesspat[1], [0, 1, 0, 1]))


### PR DESCRIPTION
This pull request extends the SWIG interface for python to include the `hess_pat` method. In addition, a test method is added to the examples directory.

While I tried to match the same style as the other interface methods, I had difficulty, given that the size of the sparsity pattern matrix is not known from the outset. As such, the return for `hess_pat` is different from the C++ interface, in that there are `start` and `index` arrays for the row compressed format.