### PR TITLE
added an option for switching between static and shared library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,51 @@ jobs:
             build_type: [Debug, Release]
             c_compiler: [gcc, clang]
             cpp_compiler: [g++, clang++]
+            build_shared_libs: [true, false]
             include:
               # macOS: only use clang/clang++
               - os: macos-latest
                 build_type: Debug
                 c_compiler: clang
                 cpp_compiler: clang++
+                build_shared_libs: true
               - os: macos-latest
                 build_type: Release
                 c_compiler: clang
                 cpp_compiler: clang++
-          
+                build_shared_libs: true
+              - os: macos-latest
+                build_type: Debug
+                c_compiler: clang
+                cpp_compiler: clang++
+                build_shared_libs: false
+              - os: macos-latest
+                build_type: Release
+                c_compiler: clang
+                cpp_compiler: clang++
+                build_shared_libs: false
+
               # Windows: only use MSVC
               - os: windows-latest
                 build_type: Debug
                 c_compiler: msvc
                 cpp_compiler: msvc
+                build_shared_libs: true
               - os: windows-latest
                 build_type: Release
                 c_compiler: msvc
-                cpp_compiler: msvc              
-
+                cpp_compiler: msvc
+                build_shared_libs: true
+              - os: windows-latest
+                build_type: Debug
+                c_compiler: msvc
+                cpp_compiler: msvc
+                build_shared_libs: false
+              - os: windows-latest
+                build_type: Release
+                c_compiler: msvc
+                cpp_compiler: msvc
+                build_shared_libs: false
 
         steps:
         - uses: actions/checkout@v4
@@ -57,6 +81,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
             -DENABLE_DOCEXA=1
             -DENABLE_ADDEXA=1
+            -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libs }}
             -S ${{ github.workspace }}
 
         - name: Configure and build ADOL-C (Windows)
@@ -64,7 +89,12 @@ jobs:
           shell: powershell
           run: 
             # Setup Visual Studio build environment
-            cmake -B ${{ steps.strings.outputs.build-output-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_DOCEXA=1 -DENABLE_ADDEXA=1 -S ${{ github.workspace }}
+            cmake -B ${{ steps.strings.outputs.build-output-dir }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+            -DENABLE_DOCEXA=1
+            -DENABLE_ADDEXA=1
+            -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libs }}
+            -S ${{ github.workspace }}
 
         - name: Build
           # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,17 @@
 
-name: Build 
+name: Build
 on:
     push:
       branches: [ "master" ]
     pull_request:
       branches: [ "master" ]
 
-jobs: 
+jobs:
     build:
         runs-on: ${{ matrix.os }}
-        strategy: 
+        strategy:
           fail-fast: false
-          matrix: 
+          matrix:
             os: [ubuntu-latest]
             build_type: [Debug, Release]
             c_compiler: [gcc, clang]
@@ -64,7 +64,7 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
-        
+
         - name: Set reusable strings
           # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
           id: strings
@@ -74,7 +74,7 @@ jobs:
 
         - name: Configure and build ADOL-C (Linux, MacOs)
           if: matrix.c_compiler != 'msvc'
-          run: > 
+          run: >
             cmake -B ${{ steps.strings.outputs.build-output-dir }}
             -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
@@ -87,7 +87,7 @@ jobs:
         - name: Configure and build ADOL-C (Windows)
           if: matrix.c_compiler == 'msvc'
           shell: powershell
-          run: 
+          run:
             # Setup Visual Studio build environment
             cmake -B ${{ steps.strings.outputs.build-output-dir }}
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -99,9 +99,3 @@ jobs:
         - name: Build
           # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
           run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
-          
-
-                    
-
-
-        

--- a/ADOL-C/include/adolc/adolcexport.h
+++ b/ADOL-C/include/adolc/adolcexport.h
@@ -6,7 +6,7 @@
  * a user builds its code with adolc that the symbols are defined somewhere
  * else.
  */
-#ifdef _WIN32
+#if defined(_WIN32) && defined(ADOLC_SHARED)
 #ifdef BUILD_ADOLC
 #define ADOLC_API __declspec(dllexport)
 #else

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,6 @@ project(adol-c
   DESCRIPTION "A Package for Automatic Differentiation of Algorithms Written in C/C++"
   HOMEPAGE_URL "https://github.com/coin-or/ADOL-C")
 
-add_library(adolc)
-add_library(adolc::adolc ALIAS adolc)
-
-target_compile_features(adolc PUBLIC cxx_std_20)
-
 # Enforce C++20
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -35,6 +30,13 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 else()
     message(WARNING "Unknown compiler — C++20 compatibility not guaranteed.")
 endif()
+
+
+# definition of library target
+add_library(adolc)
+add_library(adolc::adolc ALIAS adolc)
+
+target_compile_features(adolc PUBLIC cxx_std_20)
 
 
 # Make the version of ADOL-C available as compile definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,11 +206,11 @@ if(BUILD_INTERFACE)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
     add_subdirectory(ADOL-C/c_interface)
     install(TARGETS ADOLCInterface EXPORT ADOLCInterfaceTargets)
-    install(EXPORT ADOLCInterfaceTargets 
+    install(EXPORT ADOLCInterfaceTargets
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/adolc)
 endif()
 
-# build the tests 
+# build the tests
 # ------------------------------------
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ add_library(adolc::adolc ALIAS adolc)
 
 target_compile_features(adolc PUBLIC cxx_std_20)
 
-cmake_minimum_required(VERSION 3.15)
-project(MyProject CXX)
-
 # Enforce C++20
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if (WIN32)
 endif(WIN32)
 
 if (BUILD_SHARED_LIBS)
-  target_compile_definitions(adolc PRIVATE ADOLC_SHARED)
+  target_compile_definitions(adolc PUBLIC ADOLC_SHARED)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(adol-c
   DESCRIPTION "A Package for Automatic Differentiation of Algorithms Written in C/C++"
   HOMEPAGE_URL "https://github.com/coin-or/ADOL-C")
 
-add_library(adolc SHARED)
+add_library(adolc)
 add_library(adolc::adolc ALIAS adolc)
 
 target_compile_features(adolc PUBLIC cxx_std_20)
@@ -49,8 +49,12 @@ target_compile_definitions(adolc PRIVATE
 
 # ensures that our api is exported in windows
 if (WIN32)
-  target_compile_definitions(adolc PRIVATE BUILD_ADOLC)   
-endif(WIN32) 
+  target_compile_definitions(adolc PRIVATE BUILD_ADOLC)
+endif(WIN32)
+
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(adolc PRIVATE ADOLC_SHARED)
+endif()
 
 
 # Set the public include directory containing headers that will be installed
@@ -74,6 +78,11 @@ target_include_directories(adolc
 # --------------
 
 include(FeatureSummary)
+
+# Whether to build ADOL-C as a shared library
+# see also https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html
+option(BUILD_SHARED_LIBS "build ADOL-C as a shared library" TRUE)
+add_feature_info(BUILD_SHARED_LIBS BUILD_SHARED_LIBS "build ADOL-C as a shared library")
 
 # Whether to build ADOL-C with MeDiPack (MPI) support
 option(ENABLE_MEDIPACK "Build ADOL-C with MeDiPack (MPI) support" FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,47 +32,6 @@ else()
 endif()
 
 
-# definition of library target
-add_library(adolc)
-add_library(adolc::adolc ALIAS adolc)
-
-target_compile_features(adolc PUBLIC cxx_std_20)
-
-
-# Make the version of ADOL-C available as compile definitions
-target_compile_definitions(adolc PRIVATE
-  ADOLC_VERSION=${adol-c_VERSION_MAJOR}
-  ADOLC_SUBVERSION=${adol-c_VERSION_MINOR}
-  ADOLC_PATCHLEVEL=${adol-c_VERSION_PATCH})
-
-
-# ensures that our api is exported in windows
-if (WIN32)
-  target_compile_definitions(adolc PRIVATE BUILD_ADOLC)
-endif(WIN32)
-
-if (BUILD_SHARED_LIBS)
-  target_compile_definitions(adolc PUBLIC ADOLC_SHARED)
-endif()
-
-
-# Set the public include directory containing headers that will be installed
-target_include_directories(adolc
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ADOL-C/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ADOL-C/include> # for adolc_settings.h if one uses fetchcontent
-    $<INSTALL_INTERFACE:include>)
-
-# Set an include directory for the internally used library headers.
-#
-# This includes the files uni5_for.cpp, fo_rev.cpp, and ho_rev.cpp. Even though
-# they end with .cpp, they are used like header files.  Together with some
-# preprocessor trickery this is an old-fashioned way to do generic programming.
-target_include_directories(adolc
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ADOL-C/src>)
-
-
 # define options
 # --------------
 
@@ -143,6 +102,47 @@ option(BUILD_INTERFACE OFF)
 # build the tests
 option(BUILD_TESTS OFF)
 
+
+# definition of library target
+# ----------------------------
+
+add_library(adolc)
+add_library(adolc::adolc ALIAS adolc)
+
+target_compile_features(adolc PUBLIC cxx_std_20)
+
+# Make the version of ADOL-C available as compile definitions
+target_compile_definitions(adolc PRIVATE
+  ADOLC_VERSION=${adol-c_VERSION_MAJOR}
+  ADOLC_SUBVERSION=${adol-c_VERSION_MINOR}
+  ADOLC_PATCHLEVEL=${adol-c_VERSION_PATCH})
+
+
+# ensures that our api is exported in windows
+if (WIN32)
+  target_compile_definitions(adolc PRIVATE BUILD_ADOLC)
+endif(WIN32)
+
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(adolc PUBLIC ADOLC_SHARED)
+endif()
+
+
+# Set the public include directory containing headers that will be installed
+target_include_directories(adolc
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ADOL-C/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/ADOL-C/include> # for adolc_settings.h if one uses fetchcontent
+    $<INSTALL_INTERFACE:include>)
+
+# Set an include directory for the internally used library headers.
+#
+# This includes the files uni5_for.cpp, fo_rev.cpp, and ho_rev.cpp. Even though
+# they end with .cpp, they are used like header files.  Together with some
+# preprocessor trickery this is an old-fashioned way to do generic programming.
+target_include_directories(adolc
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ADOL-C/src>)
 
 
 # handle the options

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Customize the build with the following options
 
   `-DBUILD_TESTS=1` Build the tests (default=False)
 
+  `-DBUILD_SHARED_LIBS=0` Build as shared library (default=True)
+
 
 
 ## Examples


### PR DESCRIPTION
One way to work around #151 was to build adol-c as a static library rather than a shared library. I changed the `CMakeLists.txt` and the `adolcexport.h` to make this possible. This compiles fine in both configurations and allows to run the traceless_vector example when compiled as static library with MSVC under Windows.