### PR TITLE
[REF] Simplify the tape work modes to WRITE_, READ_ACCESS and NO_MODE

### DIFF
--- a/ADOL-C/boost-test/valuetape/tapeinfos.cpp
+++ b/ADOL-C/boost-test/valuetape/tapeinfos.cpp
@@ -16,7 +16,6 @@ BOOST_AUTO_TEST_CASE(TestConstructorTapeId) {
 
 BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   TapeInfos tp(3);
-  tp.inUse = 1;
   tp.numInds = 10;
   tp.numDeps = 11;
 
@@ -91,7 +90,7 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
 
   tp.gDegree = 31;
   tp.numTay = 45;
-  tp.workMode = TapeInfos::TAPING;
+  tp.workMode = TapeInfos::NO_MODE;
 
   auto e = new double *[10];
   tp.dpp_T = e;
@@ -119,7 +118,6 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   //======================================
   TapeInfos tp2(std::move(tp));
   BOOST_CHECK_EQUAL(tp2.tapeId_, 3);
-  BOOST_CHECK_EQUAL(tp2.inUse, 1);
   BOOST_CHECK_EQUAL(tp2.numInds, 10);
   BOOST_CHECK_EQUAL(tp2.numDeps, 11);
   BOOST_CHECK_EQUAL(tp2.keepTaylors, 1);
@@ -145,7 +143,7 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   BOOST_CHECK_EQUAL(tp2.numDirs_rev, 4);
   BOOST_CHECK_EQUAL(tp2.gDegree, 31);
   BOOST_CHECK_EQUAL(tp2.numTay, 45);
-  BOOST_CHECK_EQUAL(tp2.workMode, TapeInfos::TAPING);
+  BOOST_CHECK_EQUAL(tp2.workMode, TapeInfos::NO_MODE);
   BOOST_CHECK_EQUAL(tp2.ext_diff_fct_index, 5);
   BOOST_CHECK_EQUAL(tp2.in_nested_ctx, 4);
   BOOST_CHECK_EQUAL(tp2.numSwitches, 6);

--- a/ADOL-C/include/adolc/checkpointing.h
+++ b/ADOL-C/include/adolc/checkpointing.h
@@ -55,9 +55,7 @@ struct ADOLC_API CpInfos {
   double *dp_internal_for{nullptr};
   double *dp_internal_rev{nullptr};
   double **dpp_internal_rev{nullptr};
-  size_t index{0}; /* please do not change */
-  char modeForward{0};
-  char modeReverse{0};
+  size_t index{0};       /* please do not change */
   char *allmem{nullptr}; /* this is dummy to get externfcts and checkpointing
                    both use buffer_temp without a problem */
 };

--- a/ADOL-C/include/adolc/valuetape/tapeinfos.h
+++ b/ADOL-C/include/adolc/valuetape/tapeinfos.h
@@ -37,22 +37,7 @@ struct TapeInfos {
   };
 
   // modes for the tape evaluation; set by functions like "fos_forward"
-  enum WORKMODES {
-    ADOLC_NO_MODE,
-
-    ZOS_FORWARD,
-    FOS_FORWARD,
-    FOV_FORWARD,
-    HOS_FORWARD,
-    HOV_FORWARD,
-
-    FOS_REVERSE,
-    FOV_REVERSE,
-    HOS_REVERSE,
-    HOV_REVERSE,
-
-    TAPING
-  };
+  enum WORKMODES { NO_MODE, WRITE_ACCESS, READ_ACCESS };
 
   ~TapeInfos();
   TapeInfos() = default;
@@ -142,7 +127,7 @@ struct TapeInfos {
   double *dp_T0{nullptr};
   size_t gDegree{0};
   size_t numTay{0};
-  enum WORKMODES workMode;
+  enum WORKMODES workMode { NO_MODE };
 
   double **dpp_T{nullptr};
 

--- a/ADOL-C/include/adolc/valuetape/valuetape.h
+++ b/ADOL-C/include/adolc/valuetape/valuetape.h
@@ -85,8 +85,7 @@ public:
   // a tape always need a tapeId,
   ValueTape() = delete;
   ValueTape(short tapeId)
-      : tapeInfos_(tapeId), globalTapeVars_(),
-        perTapeInfos_(tapeId, readConfigFile()),
+      : tapeInfos_(tapeId), perTapeInfos_(tapeId, readConfigFile()),
         ext_buffer_(edf_zero_wrapper<ext_diff_fct>),
         ext2_buffer_(edf_zero_wrapper<ext_diff_fct_v2>),
         cp_buffer_(init_CpInfos) {}
@@ -431,8 +430,6 @@ public:
   size_t get_num_param() { return tapeInfos_.stats[TapeInfos::NUM_PARAM]; }
   void set_nested_ctx(char nested) { tapeInfos_.in_nested_ctx = nested; }
   char currently_nested() { return tapeInfos_.in_nested_ctx; }
-  int inUse() const { return tapeInfos_.inUse; }
-  void inUse(int val) { tapeInfos_.inUse = val; }
   char tapingComplete() const { return tapeInfos_.tapingComplete; }
   void tapingComplete(char val) { tapeInfos_.tapingComplete = val; }
   FILE *tay_file() const { return tapeInfos_.tay_file; }
@@ -710,10 +707,6 @@ public:
   // close open tapes, update stats and clean up
   void close_tape(int flag);
 
-  // release the current tape and give control to the previous one
-  // if keepVS is not zero (keep value stack for reverse) => belonging
-  // TapeInfos are kept marked as being in use
-  void releaseTape();
   /****************************************************************************/
   /* Discards parameters from the end of value tape during reverse mode */
   /****************************************************************************/
@@ -725,7 +718,7 @@ public:
    */
   /* forward call after setting the parameters. */
   /****************************************************************************/
-  void set_param_vec(short tag, size_t numparam, double *paramvec);
+  void set_param_vec(short tag, size_t numparam, const double *paramvec);
   void save_params();
   /****************************************************************************/
   /* Frees parameter indices after taping is complete */

--- a/ADOL-C/src/adolcerror.cpp
+++ b/ADOL-C/src/adolcerror.cpp
@@ -43,7 +43,7 @@ void printError() {
     message += ">>> " + std::string(std::strerror(errno)) + " <<<\n";
     break;
   }
-  std::cout << message << std::endl;
+  std::cerr << message << std::endl;
 }
 
 // outputs an appropriate error message using ADOLCError and exits the running

--- a/ADOL-C/src/checkpointing.cpp
+++ b/ADOL-C/src/checkpointing.cpp
@@ -281,9 +281,6 @@ int cp_zos_forward(short tapeId, size_t, double *, size_t, double *) {
   if (!cpInfos)
     ADOLCError::fail(ADOLCError::ErrorType::CP_NO_SUCH_IDX, CURRENT_LOCATION,
                      ADOLCError::FailInfo{.info2 = tape.cp_index()});
-  // note the mode
-  cpInfos->modeForward = TapeInfos::ZOS_FORWARD;
-  cpInfos->modeReverse = TapeInfos::ADOLC_NO_MODE;
 
   // prepare arguments
   cpInfos->dp_internal_for = new double[cpInfos->dim];
@@ -346,9 +343,6 @@ int cp_fos_reverse(short tapeId, size_t, double *, size_t, double *, double *,
   ValueTape &tape = findTape(tapeId);
 
   CpInfos *cpInfos = tape.get_cp_fct(tape.cp_index());
-
-  // note the mode
-  cpInfos->modeReverse = TapeInfos::FOS_REVERSE;
 
   cpInfos->dp_internal_for = new double[cpInfos->dim];
   cpInfos->dp_internal_rev = new double[cpInfos->dim];
@@ -450,9 +444,6 @@ int cp_fov_reverse(short tapeId, size_t, size_t, double **, size_t, double **,
   ValueTape &tape = findTape(tapeId);
 
   CpInfos *cpInfos = tape.get_cp_fct(tape.cp_index());
-
-  // note the mode
-  cpInfos->modeReverse = TapeInfos::FOV_REVERSE;
 
   const int numDirs = tape.numDirs_rev();
   cpInfos->dp_internal_for = new double[cpInfos->dim];

--- a/ADOL-C/src/fo_rev.cpp
+++ b/ADOL-C/src/fo_rev.cpp
@@ -457,7 +457,6 @@ int int_reverse_safe(
   rp_A = myalloc1(tape.tapestats(TapeInfos::NUM_MAX_LIVES));
   tape.rp_A(rp_A);
   rp_T = myalloc1(tape.tapestats(TapeInfos::NUM_MAX_LIVES));
-  tape.workMode(TapeInfos::FOS_REVERSE);
 #ifdef _ABS_NORM_
   memset(results, 0, sizeof(double) * (indep + swchk));
 #endif
@@ -479,7 +478,6 @@ int int_reverse_safe(
   rpp_A = myalloc2(tape.tapestats(TapeInfos::NUM_MAX_LIVES), p);
   tape.rpp_A(rpp_A);
   rp_T = myalloc1(tape.tapestats(TapeInfos::NUM_MAX_LIVES));
-  tape.workMode(TapeInfos::FOV_REVERSE);
 #define ADJOINT_BUFFER rpp_A
 #define ADJOINT_BUFFER_ARG_L rpp_A[arg][l]
 #define ADJOINT_BUFFER_RES_L rpp_A[res][l]
@@ -2980,7 +2978,6 @@ int int_reverse_safe(
 #endif
 #endif
 
-  tape.workMode(TapeInfos::ADOLC_NO_MODE);
   tape.end_sweep();
 
   return ret_c;

--- a/ADOL-C/src/ho_rev.cpp
+++ b/ADOL-C/src/ho_rev.cpp
@@ -422,7 +422,6 @@ int hov_ti_reverse(
   rp_Atemp = myalloc1(k1);
   rp_Atemp2 = myalloc1(k1);
   rp_Ttemp2 = myalloc1(k);
-  tape.workMode(TapeInfos::HOS_REVERSE);
 
   locint n, m;
   ext_diff_fct *edfct = nullptr;
@@ -434,7 +433,6 @@ int hov_ti_reverse(
   rp_Atemp = myalloc1(pk1);
   rp_Atemp2 = myalloc1(pk1);
   rp_Ttemp2 = myalloc1(k);
-  tape.workMode(TapeInfos::HOV_REVERSE);
   /*----------------------------------------------------------------------*/
 #elif _HOS_OV_ /* HOS_OV */
   rpp_A = myalloc2(tape.tapestats(TapeInfos::NUM_MAX_LIVES), pk1);
@@ -442,7 +440,6 @@ int hov_ti_reverse(
   rp_Atemp = myalloc1(pk1);
   rp_Atemp2 = myalloc1(pk1);
   rp_Ttemp2 = myalloc1(p * k);
-  tape.workMode(TapeInfos::HOV_REVERSE);
 #endif
   rp_Ttemp = myalloc1(k);
   x = myalloc1(q);
@@ -3007,7 +3004,6 @@ int hov_ti_reverse(
   myfree1_ulong(jj);
   myfree1(x);
 
-  tape.workMode(TapeInfos::ADOLC_NO_MODE);
   tape.end_sweep();
 
   return ret_c;

--- a/ADOL-C/src/tape_interface.cpp
+++ b/ADOL-C/src/tape_interface.cpp
@@ -91,18 +91,19 @@ int trace_on(short tapeId, int keepTaylors, size_t obs, size_t lbs, size_t vbs,
 }
 
 void trace_off(int flag) {
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::TAPING_NOT_ACTUALLY_TAPING;
 
   ValueTape &tape = currentTape();
-  if (tape.workMode() != TapeInfos::TAPING)
-    ADOLCError::fail(ADOLCError::ErrorType::TAPING_NOT_ACTUALLY_TAPING,
-                     CURRENT_LOCATION,
-                     ADOLCError::FailInfo{.info1 = tape.tapeId()});
+  if (tape.workMode() != TapeInfos::WRITE_ACCESS)
+    fail(TAPING_NOT_ACTUALLY_TAPING, CURRENT_LOCATION,
+         FailInfo{.info1 = tape.tapeId()});
   tape.keepTape(flag);
   tape.keep_stock(); /* copy remaining live variables + trace_flag = 0 */
   tape.stop_trace(flag);
   tape.tapingComplete(1);
-  tape.workMode(TapeInfos::ADOLC_NO_MODE);
-  tape.releaseTape();
+  tape.workMode(TapeInfos::NO_MODE);
 
   // restore previous tapeId and delete it
   setCurrentTape(currentTapeStack().top());

--- a/ADOL-C/src/uni5_for.cpp
+++ b/ADOL-C/src/uni5_for.cpp
@@ -1119,7 +1119,6 @@ int hov_forward(
   tape.dpp_T(&dp_T0);
   tape.numTay(0);
   tape.gDegree(0);
-  tape.workMode(TapeInfos::ZOS_FORWARD);
 #endif             /* !_NTIGHT_ */
 #if defined(_ZOS_) /* ZOS */
 
@@ -1147,7 +1146,6 @@ int hov_forward(
   tape.dpp_T(&dp_T);
   tape.numTay(1);
   tape.gDegree(1);
-  tape.workMode(TapeInfos::FOS_FORWARD);
 #define TAYLOR_BUFFER dp_T
 #if defined(_KEEP_)
   if (keep) {
@@ -1211,7 +1209,6 @@ int hov_forward(
   tape.dpp_T(dpp_T);
   tape.numTay(p);
   tape.gDegree(1);
-  tape.workMode(TapeInfos::FOV_FORWARD);
 #define TAYLOR_BUFFER dpp_T
   dp_Ttemp = myalloc1(p);
 #define T_TEMP dp_Ttemp;
@@ -1223,7 +1220,6 @@ int hov_forward(
   tape.dpp_T(dpp_T);
   tape.numTay(1);
   tape.gDegree(k);
-  tape.workMode(TapeInfos::HOS_FORWARD);
 #define TAYLOR_BUFFER dpp_T
   dp_z = myalloc1(k);
   dp_Ttemp = myalloc1(k);
@@ -1241,7 +1237,6 @@ int hov_forward(
   tape.dpp_T(dpp_T);
   tape.numTay(p);
   tape.gDegree(k);
-  tape.workMode(TapeInfos::HOV_FORWARD);
 #define TAYLOR_BUFFER dpp_T
   dp_z = myalloc1(k);
   dp_Ttemp = myalloc1(p * k);
@@ -5933,7 +5928,6 @@ int hov_forward(
   myfree1(dp_z);
 #endif
 
-  tape.workMode(TapeInfos::ADOLC_NO_MODE);
   tape.end_sweep();
 
 #if defined(_INDO_)

--- a/ADOL-C/src/valuetape/persistanttapeinfos.cpp
+++ b/ADOL-C/src/valuetape/persistanttapeinfos.cpp
@@ -22,27 +22,27 @@ PersistantTapeInfos::~PersistantTapeInfos() {
   myfree1(forodec_y);
 
   if (op_fileName) {
-    if (!(keepTape && skipFileCleanup))
+    if (keepTape == 0 || skipFileCleanup == 0)
       remove(op_fileName);
     delete[] op_fileName;
     op_fileName = nullptr;
   }
   if (val_fileName) {
-    if (!(keepTape && skipFileCleanup))
+    if (keepTape == 0 || skipFileCleanup == 0)
       remove(val_fileName);
     delete[] val_fileName;
     val_fileName = nullptr;
   }
 
   if (loc_fileName) {
-    if (!(keepTape && skipFileCleanup))
+    if (keepTape == 0 || skipFileCleanup == 0)
       remove(loc_fileName);
     delete[] loc_fileName;
     loc_fileName = nullptr;
   }
 
   if (tay_fileName) {
-    if (!(keepTape && skipFileCleanup))
+    if (keepTape == 0 || skipFileCleanup == 0)
       remove(tay_fileName);
     delete[] tay_fileName;
     tay_fileName = nullptr;

--- a/ADOL-C/src/valuetape/tapeinfos.cpp
+++ b/ADOL-C/src/valuetape/tapeinfos.cpp
@@ -45,19 +45,19 @@ TapeInfos::~TapeInfos() {
 }
 
 TapeInfos::TapeInfos(TapeInfos &&other) noexcept
-    : tapeId_(other.tapeId_), inUse(other.inUse), numInds(other.numInds),
-      numDeps(other.numDeps), keepTaylors(other.keepTaylors),
-      traceFlag(other.traceFlag), tapingComplete(other.tapingComplete),
-      op_file(other.op_file), opBuffer(other.opBuffer), currOp(other.currOp),
-      lastOpP1(other.lastOpP1), numOps_Tape(other.numOps_Tape),
-      num_eq_prod(other.num_eq_prod), val_file(other.val_file),
-      valBuffer(other.valBuffer), currVal(other.currVal),
-      lastValP1(other.lastValP1), numVals_Tape(other.numVals_Tape),
-      loc_file(other.loc_file), locBuffer(other.locBuffer),
-      currLoc(other.currLoc), lastLocP1(other.lastLocP1),
-      numLocs_Tape(other.numLocs_Tape), tay_file(other.tay_file),
-      tayBuffer(other.tayBuffer), currTay(other.currTay),
-      lastTayP1(other.lastTayP1), numTays_Tape(other.numTays_Tape),
+    : tapeId_(other.tapeId_), numInds(other.numInds), numDeps(other.numDeps),
+      keepTaylors(other.keepTaylors), traceFlag(other.traceFlag),
+      tapingComplete(other.tapingComplete), op_file(other.op_file),
+      opBuffer(other.opBuffer), currOp(other.currOp), lastOpP1(other.lastOpP1),
+      numOps_Tape(other.numOps_Tape), num_eq_prod(other.num_eq_prod),
+      val_file(other.val_file), valBuffer(other.valBuffer),
+      currVal(other.currVal), lastValP1(other.lastValP1),
+      numVals_Tape(other.numVals_Tape), loc_file(other.loc_file),
+      locBuffer(other.locBuffer), currLoc(other.currLoc),
+      lastLocP1(other.lastLocP1), numLocs_Tape(other.numLocs_Tape),
+      tay_file(other.tay_file), tayBuffer(other.tayBuffer),
+      currTay(other.currTay), lastTayP1(other.lastTayP1),
+      numTays_Tape(other.numTays_Tape),
       numTBuffersInUse(other.numTBuffersInUse),
       nextBufferNumber(other.nextBufferNumber),
       lastTayBlockInCore(other.lastTayBlockInCore), T_for(other.T_for),
@@ -128,7 +128,6 @@ TapeInfos &TapeInfos::operator=(TapeInfos &&other) noexcept {
 
     // **2. Move data members**
     tapeId_ = other.tapeId_;
-    inUse = other.inUse;
     numInds = other.numInds;
     numDeps = other.numDeps;
     keepTaylors = other.keepTaylors;

--- a/ADOL-C/src/valuetape/valuetape.cpp
+++ b/ADOL-C/src/valuetape/valuetape.cpp
@@ -3,10 +3,7 @@
 #include <adolc/internal/common.h>
 #include <adolc/tape_interface.h>
 #include <adolc/valuetape/valuetape.h>
-#include <algorithm>
 #include <cassert>
-#include <iostream>
-#include <ranges>
 #include <span>
 #include <string>
 #include <sys/stat.h> // used in readconfigFile
@@ -30,7 +27,7 @@ void ValueTape::initTapeInfos_keep() {
   short tapeId = tapeInfos_.tapeId_;
 
   // keep the stats to later know the number of indeps, etc...
-  auto tmp_stats = std::move(tapeInfos_.stats);
+  auto tmp_stats = tapeInfos_.stats;
 
   // make sure the destructor will not destroy them
   tapeInfos_.opBuffer = nullptr;
@@ -41,7 +38,7 @@ void ValueTape::initTapeInfos_keep() {
   tapeInfos_.tay_file = nullptr;
 
   tapeInfos_ = TapeInfos();
-  tapeInfos_.stats = std::move(tmp_stats);
+  tapeInfos_.stats = tmp_stats;
 
   tapeInfos_.opBuffer = opBuffer;
   tapeInfos_.locBuffer = locBuffer;
@@ -56,26 +53,13 @@ void ValueTape::initTapeInfos_keep() {
  * - returns 0 without error
  * - returns 1 if tapeId was already/still in use */
 int ValueTape::initNewTape() {
-  int retval = 0;
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::TAPING_TAPE_STILL_IN_USE;
 
-  if (inUse()) {
-    if (!tapingComplete())
-      ADOLCError::fail(ADOLCError::ErrorType::TAPING_TAPE_STILL_IN_USE,
-                       CURRENT_LOCATION,
-                       ADOLCError::FailInfo{.info1 = tapeId()});
-
-    if (!tapestats(TapeInfos::OP_FILE_ACCESS) &&
-        !tapestats(TapeInfos::LOC_FILE_ACCESS) &&
-        !tapestats(TapeInfos::VAL_FILE_ACCESS)) {
-#if defined(ADOLC_DEBUG)
-      fprintf(DIAG_OUT,
-              "\nADOL-C warning: Tape %d existed in main memory"
-              " only and gets overwritten!\n\n",
-              tapeId());
-#endif
-      /* free associated resources */
-      retval = 1;
-    }
+  if (workMode() != TapeInfos::NO_MODE) {
+    fail(TAPING_TAPE_STILL_IN_USE, CURRENT_LOCATION,
+         FailInfo{.info1 = tapeId()});
   }
   if (tay_file())
     rewind(tay_file());
@@ -83,13 +67,12 @@ int ValueTape::initNewTape() {
   // creates new tapeInfos object with old buffers
   // thus, we dont allocate the buffers again if they are already existent
   initTapeInfos_keep();
+  // must be after initTapeInfos_keep, to not get overwritten!
+  workMode(TapeInfos::WRITE_ACCESS);
 #ifdef SPARSE
   initSparse();
 #endif
-
   traceFlag(1);
-  inUse(1);
-
   // those are the old values from the globaltapevars
   // require to init the tape-buffers with correct size
   // or set the last location pointers.
@@ -98,34 +81,32 @@ int ValueTape::initNewTape() {
   tapestats(TapeInfos::VAL_BUFFER_SIZE, valueBufferSize());
   tapestats(TapeInfos::TAY_BUFFER_SIZE, taylorBufferSize());
   skipFileCleanup(0);
-  return retval;
+  return 0;
 }
 
 /* opens an existing tape or creates a new handle for a tape on hard disk
  * - called from init_for_sweep and init_rev_sweep */
 void ValueTape::openTape() {
-  /* tape has been used before (in the current program) */
-  if (!inUse()) {
-    /* forward sweep */
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::TAPING_TAPE_STILL_IN_USE;
+  // check if we are currently writing to the tape, which is not allowed when we
+  // want to read.
+  if (workMode() == TapeInfos::WRITE_ACCESS) {
+    fail(TAPING_TAPE_STILL_IN_USE, CURRENT_LOCATION,
+         FailInfo{.info1 = tapeId()});
+  } else if (keepTaylors() == 0 && tapestats(TapeInfos::OP_FILE_ACCESS) == 1 &&
+             tapestats(TapeInfos::LOC_FILE_ACCESS) == 1 &&
+             tapestats(TapeInfos::VAL_FILE_ACCESS) == 1) {
     if (tay_file())
       rewind(tay_file());
     initTapeInfos_keep();
     traceFlag(1);
     tapingComplete(1);
-    inUse(1);
     read_tape_stats();
   }
-}
-
-/* release the current tape and give control to the previous one */
-void ValueTape::releaseTape() {
-  /* if operations, locations and constants tapes have been written and value
-   * stack information have not been created tapeInfos are no longer needed*/
-  if (!keepTaylors() && tapestats(TapeInfos::OP_FILE_ACCESS) == 1 &&
-      tapestats(TapeInfos::LOC_FILE_ACCESS) == 1 &&
-      tapestats(TapeInfos::VAL_FILE_ACCESS) == 1) {
-    inUse(0);
-  }
+  // must be after initTapeInfos_keep, to not get overwritten!
+  workMode(TapeInfos::READ_ACCESS);
 }
 
 /* record all existing adoubles on the tape
@@ -197,6 +178,11 @@ size_t ValueTape::keep_stock() {
 /* Set up statics for writing taylor data                                   */
 /****************************************************************************/
 void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::TAPING_TBUFFER_ALLOCATION_FAILED;
+  using ADOLCError::ErrorType::TAPING_TO_MANY_TAYLOR_BUFFERS;
+
   if (tayBuffer()) {
 #if defined(ADOLC_DEBUG)
     fprintf(DIAG_OUT,
@@ -207,8 +193,7 @@ void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
     taylor_close(false);
   } else { /* check if new buffer is allowed */
     if (numTBuffersInUse() == maxNumberTaylorBuffers())
-      ADOLCError::fail(ADOLCError::ErrorType::TAPING_TO_MANY_TAYLOR_BUFFERS,
-                       CURRENT_LOCATION);
+      fail(TAPING_TO_MANY_TAYLOR_BUFFERS, CURRENT_LOCATION);
 
     increment_numTBuffersInUse();
     if (tay_fileName() == nullptr)
@@ -220,16 +205,13 @@ void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
     tayBuffer(new double[bufferSize]);
 
   if (tayBuffer() == nullptr)
-    ADOLCError::fail(ADOLCError::ErrorType::TAPING_TBUFFER_ALLOCATION_FAILED,
-                     CURRENT_LOCATION);
+    fail(TAPING_TBUFFER_ALLOCATION_FAILED, CURRENT_LOCATION);
 
   deg_save(degreeSave);
   if (degreeSave >= 0)
     keepTaylors(1);
   currTay(tayBuffer());
   lastTayP1(currTay() + bufferSize);
-  inUse(1);
-
   numTays_Tape(0);
 }
 
@@ -457,7 +439,6 @@ void ValueTape::start_trace() {
 
   num_eq_prod(0);
   numSwitches(0);
-  workMode(TapeInfos::TAPING);
 
   /* Put operation denoting the start_of_the tape */
   put_op(start_of_tape);
@@ -586,7 +567,7 @@ void ValueTape::close_tape(int flag) {
   tapestats(TapeInfos::NUM_VALUES, numVals_Tape());
 
   /* finish locations tape, update and write tape stats, close tape */
-  if (flag != 0 || loc_file()) {
+  if (flag != 0 || (loc_file() != nullptr)) {
     if (currLoc() != locBuffer()) {
       put_loc_block(currLoc());
     }
@@ -693,7 +674,12 @@ void ValueTape::read_params() {
 /* the taylor stack, so next reverse call will fail, if not preceded by a   */
 /* forward call after setting the parameters.                               */
 /****************************************************************************/
-void ValueTape::set_param_vec(short tag, size_t numparam, double *paramvec) {
+void ValueTape::set_param_vec(short tag, size_t numparam,
+                              const double *paramvec) {
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::PARAM_COUNTS_MISMATCH;
+
   /* mark possible (hard disk) tape creation */
   markNewTape();
 
@@ -701,11 +687,10 @@ void ValueTape::set_param_vec(short tag, size_t numparam, double *paramvec) {
    * stack information */
   openTape();
   if (tapestats(TapeInfos::NUM_PARAM) != numparam)
-    ADOLCError::fail(
-        ADOLCError::ErrorType::PARAM_COUNTS_MISMATCH, CURRENT_LOCATION,
-        ADOLCError::FailInfo{.info1 = tag,
-                             .info5 = numparam,
-                             .info6 = tapeInfos_.stats[TapeInfos::NUM_PARAM]});
+    fail(PARAM_COUNTS_MISMATCH, CURRENT_LOCATION,
+         FailInfo{.info1 = tag,
+                  .info5 = numparam,
+                  .info6 = tapeInfos_.stats[TapeInfos::NUM_PARAM]});
 
   if (!paramstore())
     paramstore(new double[tapestats(TapeInfos::NUM_PARAM)]);
@@ -715,7 +700,6 @@ void ValueTape::set_param_vec(short tag, size_t numparam, double *paramvec) {
     paramstore_view[i] = paramvec[i];
 
   taylor_close(false);
-  releaseTape();
 }
 
 /**
@@ -755,17 +739,19 @@ void ValueTape::compare_adolc_ids(const ADOLC_ID &id1, const ADOLC_ID &id2) {
 /* Does the actual reading from the hard disk into the stats buffer */
 /****************************************************************************/
 void ValueTape::read_tape_stats() {
-  if (inUse() && !tapingComplete())
-    return;
+  using ADOLCError::fail;
+  using ADOLCError::FailInfo;
+  using ADOLCError::ErrorType::INTEGER_TAPE_FOPEN_FAILED;
+  using ADOLCError::ErrorType::TAPING_TAPE_STILL_IN_USE;
 
-  FILE *loc_file = nullptr;
-  ADOLC_ID tape_ADOLC_ID;
-  if ((loc_file = fopen(loc_fileName(), "rb")) == nullptr ||
+  ADOLC_ID tape_ADOLC_ID{};
+  FILE *loc_file = fopen(loc_fileName(), "rb");
+  if (loc_file == nullptr ||
       (fread(&tape_ADOLC_ID, sizeof(ADOLC_ID), 1, loc_file) != 1) ||
       (fread(tapestats().data(), TapeInfos::STAT_SIZE * sizeof(size_t), 1,
              loc_file) != 1)) {
-    ADOLCError::fail(ADOLCError::ErrorType::INTEGER_TAPE_FOPEN_FAILED,
-                     CURRENT_LOCATION, ADOLCError::FailInfo{.info1 = tapeId()});
+    fail(INTEGER_TAPE_FOPEN_FAILED, CURRENT_LOCATION,
+         FailInfo{.info1 = tapeId()});
   }
 
   compare_adolc_ids(get_adolc_id(), tape_ADOLC_ID);
@@ -1014,10 +1000,7 @@ void ValueTape::end_sweep() {
     fclose(val_file());
     val_file(nullptr);
   }
-  if (deg_save() > 0)
-    releaseTape(); /* keep value stack */
-  else
-    releaseTape(); /* no value stack */
+  workMode(TapeInfos::NO_MODE);
 }
 
 /****************************************************************************/


### PR DESCRIPTION
This communicates the current tape state better:
- trace_on sets the tape to WRITE_ACCESS
- trace_off sets the mode from WRITE_ACCESS to NO_MODE
- if trace_off sees any other mode than WRITE_ACCESS it errors
- if the tape is evaluated openTape is used and the mode is set to READ_ACCESS
- openTape errors if the tape is currently in WRITE_ACCESS
- endsweep sets the tape to NO_MODE

The goal is to allow several read-access at the same time.

Additional I made some minor stylistic cleanups.