### PR TITLE
[REF] Change interfaces using tapeId to reference of tape

### DIFF
--- a/ADOL-C/boost-test/ho_rev/hos_ov_reverse.cpp
+++ b/ADOL-C/boost-test/ho_rev/hos_ov_reverse.cpp
@@ -10,8 +10,8 @@ namespace tt = boost::test_tools;
 BOOST_AUTO_TEST_SUITE(test_hos_ov_forward)
 
 BOOST_AUTO_TEST_CASE(PlusOperator_HOS_OV_REVERSE) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree_hov_forward = 1;
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(PlusOperator_HOS_OV_REVERSE) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); ++i)
     indep[i] <<= in[i];
 
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(PlusOperator_HOS_OV_REVERSE) {
   adouble dep = pow(indep[0], 2) + pow(indep[1], 3);
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree_hov_forward);
   double ***Y = myalloc3(dim_out, num_dirs, degree_hov_forward);
@@ -53,10 +53,10 @@ BOOST_AUTO_TEST_CASE(PlusOperator_HOS_OV_REVERSE) {
   std::vector<double> test_in{2.0, 3.2};
   // x^2 + y^3)
   double test_out = std::pow(test_in[0], 2) + std::pow(test_in[1], 3);
-  hov_wk_forward(tapeId, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
-  hos_ov_reverse(tapeId, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
+  hos_ov_reverse(*tapePtr, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
   BOOST_TEST(Y[0][0][0] == 2 * test_in[0] * X[0][0][0] +
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(PlusOperator_HOS_OV_REVERSE) {
 }
 
 BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree_hov_forward = 1;
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); ++i)
     indep[i] <<= in[i];
 
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
   adouble dep = min(pow(indep[0], 2), pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree_hov_forward);
   double ***Y = myalloc3(dim_out, num_dirs, degree_hov_forward);
@@ -156,10 +156,10 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
   // min(x^2, y^3)
   double test_out = std::min(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
-  hos_ov_reverse(tapeId, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
+  hos_ov_reverse(*tapePtr, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
   BOOST_TEST(Y[0][0][0] == 2 * test_in[0] * X[0][0][0], tt::tolerance(tol));
@@ -198,10 +198,10 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
   test_in[1] = 1.0;
   // min(x^2, y^3)
   test_out = std::min(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
-  hov_wk_forward(tapeId, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
-  hos_ov_reverse(tapeId, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
+  hos_ov_reverse(*tapePtr, dim_out, dim_in, degree_hos_reverse, num_dirs, U, Z);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
   BOOST_TEST(Y[0][0][0] == 3 * std::pow(test_in[1], 2) * X[1][0][0],
@@ -246,10 +246,10 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOS_OV_REVERSE) {
   // min(x^2, y^3)
   test_out = std::min(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
   std::cout << "tie point" << std::endl;
-  hov_wk_forward(tapeId, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree_hov_forward, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
-  hos_ov_reverse(tapeId, dim_out, dim_in, degree_hos_reverse, num_dirs, U,
+  hos_ov_reverse(*tapePtr, dim_out, dim_in, degree_hos_reverse, num_dirs, U,
                  Z);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));

--- a/ADOL-C/boost-test/integration_tests/big_example.cpp
+++ b/ADOL-C/boost-test/integration_tests/big_example.cpp
@@ -29,15 +29,14 @@ template <size_t dim> void taping() {
 
 BOOST_AUTO_TEST_CASE(BigExample) {
   constexpr size_t dim = 200'000;
-  const auto tapeId = createNewTape();
-  trace_on(tapeId, 1);
+  auto tapePtr = std::make_unique<ValueTape>();
+  trace_on(*tapePtr, 1);
   taping<dim>();
-  trace_off(1);
+  trace_off(*tapePtr, 1);
   std::vector<double> tangent(dim);
   std::vector<double> out(dim);
   std::fill(tangent.begin(), tangent.end(), 1.0);
-  // printTapeStats(tapeId);
-  gradient(tapeId, dim, tangent.data(), out.data());
+  gradient(*tapePtr, dim, tangent.data(), out.data());
   for (auto i = 0; i < out.size(); i++) {
     BOOST_TEST(out[i] == (i + 1), tt::tolerance(tol));
   }

--- a/ADOL-C/boost-test/integration_tests/determinante.cpp
+++ b/ADOL-C/boost-test/integration_tests/determinante.cpp
@@ -1,3 +1,5 @@
+#include "adolc/valuetape/valuetape.h"
+#include <memory>
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -49,8 +51,8 @@ adouble det(const T &A, size_t row,
 
 BOOST_AUTO_TEST_SUITE(test_detem_example)
 BOOST_AUTO_TEST_CASE(DeterminanteTest) {
-  const short tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   const int keep = 1;
   constexpr size_t n = 7;
@@ -58,7 +60,7 @@ BOOST_AUTO_TEST_CASE(DeterminanteTest) {
 
   std::array<std::array<adouble, n>, n> A;
 
-  trace_on(tapeId, keep); // tapeId=1=keep
+  trace_on(*tapePtr, keep);
   double detout = 0.0;
   double diag = 1.0;             // here keep the intermediates for
   for (size_t i = 0; i < n; i++) // the subsequent call to reverse
@@ -75,12 +77,12 @@ BOOST_AUTO_TEST_CASE(DeterminanteTest) {
 
   ad >>= detout;
   BOOST_TEST(detout == diag, tt ::tolerance(tol));
-  trace_off();
+  trace_off(*tapePtr);
 
   std::array<double, 1> u;
   u[0] = 1.0;
   std::array<double, n * n> B;
-  reverse(tapeId, 1, n * n, 0, u.data(),
+  reverse(*tapePtr, 1, n * n, 0, u.data(),
           B.data()); // call reverse to calculate the gradient
 
   std::array<double, n> res = {5.4071428571428601, 0, 0, 0, 0, 0, 0};

--- a/ADOL-C/boost-test/integration_tests/powerexam.cpp
+++ b/ADOL-C/boost-test/integration_tests/powerexam.cpp
@@ -1,3 +1,5 @@
+#include "adolc/valuetape/valuetape.h"
+#include <memory>
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -30,8 +32,8 @@ adouble power(adouble x, int n) {
 
 BOOST_AUTO_TEST_SUITE(test_power_example)
 BOOST_AUTO_TEST_CASE(PowerExampTest) {
-  const short tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   int n = 4;
 
   /* allocations and initializations */
@@ -48,25 +50,25 @@ BOOST_AUTO_TEST_CASE(PowerExampTest) {
 
   adouble y, x; /* declare active variables */
   /* beginning of active section */
-  trace_on(tapeId); /* tapeId = 1 and keep = 0 */
-  x <<= X[0][0];    /* only one independent var */
-  y = power(x, n);  /* actual function call */
-  y >>= Y[0][0];    /* only one dependent adouble */
-  trace_off();      /* no global adouble has died */
+  trace_on(*tapePtr);  /* *tapePtr = 1 and keep = 0 */
+  x <<= X[0][0];       /* only one independent var */
+  y = power(x, n);     /* actual function call */
+  y >>= Y[0][0];       /* only one dependent adouble */
+  trace_off(*tapePtr); /* no global adouble has died */
   /* end of active section */
 
   double u[1];                     /* weighting vector */
   u[0] = 1;                        /* for reverse call */
   for (auto i = 0; i < n + 2; i++) /* note that keep = i+1 in call */
   {
-    forward(tapeId, 1, 1, i, i + 1, X, Y); /* evaluate the i-the derivative */
+    forward(*tapePtr, 1, 1, i, i + 1, X, Y); /* evaluate the i-the derivative */
     if (i == 0)
       BOOST_TEST(Y[0][i] == y.value(), tt::tolerance(tol));
     else {
       Z[0][i] = Z[0][i - 1] / i; /* scale derivative to Taylorcoeff. */
       BOOST_TEST(Y[0][i] == Z[0][i], tt::tolerance(tol));
     }
-    reverse(tapeId, 1, 1, i, u, Z); /* evaluate the (i+1)-st deriv. */
+    reverse(*tapePtr, 1, 1, i, u, Z); /* evaluate the (i+1)-st deriv. */
   } /* end for */
   myfree2(X);
   myfree2(Y);

--- a/ADOL-C/boost-test/traceCompositeTests.cpp
+++ b/ADOL-C/boost-test/traceCompositeTests.cpp
@@ -36,20 +36,20 @@ BOOST_AUTO_TEST_SUITE(trace_composite)
 BOOST_AUTO_TEST_CASE(CompositeTrig1_FOV_Forward) {
   double x1 = 0.289, x2 = 1.927, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = sin(ax1) * sin(ax1) + cos(ax1) * cos(ax1) + ax2;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.;
   double x2Derivative = 1.;
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig1_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -88,20 +88,20 @@ BOOST_AUTO_TEST_CASE(CompositeTrig1_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeTrig1Operator_FOV_Reverse) {
   double x1 = 0.289, x2 = 1.927, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = sin(ax1) * sin(ax1) + cos(ax1) * cos(ax1) + ax2;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.;
   double x2Derivative = 1.;
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig1Operator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(2.);
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -133,14 +133,14 @@ BOOST_AUTO_TEST_CASE(CompositeTrig1Operator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeTrig2_FOV_Forward) {
   double x1 = 1.11, x2 = 2.22, x3 = 3.33, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2_FOV_Forward) {
   ax1 = 2 * sin(cos(ax1)) * exp(ax2) - pow(cos(ax3), 2) * sin(ax2);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2 * std::cos(std::cos(x1)) * std::exp(x2) * std::sin(x1);
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -193,14 +193,14 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeTrig2Operator_FOV_Reverse) {
   double x1 = 1.11, x2 = 2.22, x3 = 3.33, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2Operator_FOV_Reverse) {
   ax1 = 2 * sin(cos(ax1)) * exp(ax2) - pow(cos(ax3), 2) * sin(ax2);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2 * std::cos(std::cos(x1)) * std::exp(x2) * std::sin(x1);
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2Operator_FOV_Reverse) {
   u[1][0] = std::exp(6.);
   u[2][0] = std::log(6.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -250,14 +250,14 @@ BOOST_AUTO_TEST_CASE(CompositeTrig2Operator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeTrig3_FOV_Forward) {
   double x1 = 0.516, x2 = 9.89, x3 = 0.072, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3_FOV_Forward) {
   ax1 = pow(sin(ax1), cos(ax1) - ax2) * ax3;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(std::sin(x1), std::cos(x1) - x2) * x3 *
                         (-std::sin(x1) * std::log(std::sin(x1)) +
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -310,14 +310,14 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeTrig3Operator_FOV_Reverse) {
   double x1 = 0.516, x2 = 9.89, x3 = 0.072, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3Operator_FOV_Reverse) {
   ax1 = pow(sin(ax1), cos(ax1) - ax2) * ax3;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(std::sin(x1), std::cos(x1) - x2) * x3 *
                         (-std::sin(x1) * std::log(std::sin(x1)) +
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3Operator_FOV_Reverse) {
   u[1][0] = std::pow(10., 6.);
   u[2][0] = std::pow(6., 10.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -366,20 +366,20 @@ BOOST_AUTO_TEST_CASE(CompositeTrig3Operator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeTrig4_FOV_Forward) {
   double x1 = 1.56, x2 = 8.99, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = atan(tan(ax1)) * exp(ax2);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::exp(x2);
   double x2Derivative = x1 * std::exp(x2);
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig4_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -418,20 +418,20 @@ BOOST_AUTO_TEST_CASE(CompositeTrig4_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeTrig4Operator_FOV_Reverse) {
   double x1 = 1.56, x2 = 8.99, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = atan(tan(ax1)) * exp(ax2);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::exp(x2);
   double x2Derivative = x1 * std::exp(x2);
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(CompositeTrig4Operator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = -1.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -465,8 +465,8 @@ BOOST_AUTO_TEST_CASE(CompositeTrig4Operator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(LongSum_FOV_Forward) {
   double x1 = 0.11, x2 = -2.27, x3 = 81.7, x4 = 0.444, x5 = 4.444, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(LongSum_FOV_Forward) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(LongSum_FOV_Forward) {
   ax1 = ax1 + ax2 - ax3 + pow(ax1, 2) - 10 + sqrt(ax4 * ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 1. + 2 * x1;
   double x2Derivative = 1.;
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(LongSum_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 5, 5, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 5, 5, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -532,8 +532,8 @@ BOOST_AUTO_TEST_CASE(LongSum_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(LongSumOperator_FOV_Reverse) {
   double x1 = 0.11, x2 = -2.27, x3 = 81.7, x4 = 0.444, x5 = 4.444, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(LongSumOperator_FOV_Reverse) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE(LongSumOperator_FOV_Reverse) {
   ax1 = ax1 + ax2 - ax3 + pow(ax1, 2) - 10 + sqrt(ax4 * ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 1. + 2 * x1;
   double x2Derivative = 1.;
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(LongSumOperator_FOV_Reverse) {
   u[3][0] = 4.;
   u[4][0] = 5.;
 
-  fov_reverse(tapeId, 1, 5, 5, u, z);
+  fov_reverse(*tapePtr, 1, 5, 5, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -609,20 +609,20 @@ BOOST_AUTO_TEST_CASE(LongSumOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(InverseFunc_FOV_Forward) {
   double x1 = 3.77, x2 = -21.12, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = sqrt(pow(ax1, 2)) * ax2;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = x2;
   double x2Derivative = x1;
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(InverseFunc_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -661,20 +661,20 @@ BOOST_AUTO_TEST_CASE(InverseFunc_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(InverseFuncOperator_FOV_Reverse) {
   double x1 = 3.77, x2 = -21.12, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ax1 = sqrt(pow(ax1, 2)) * ax2;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = x2;
   double x2Derivative = x1;
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(InverseFuncOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::cos(2.);
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -709,14 +709,14 @@ BOOST_AUTO_TEST_CASE(InverseFuncOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(ExpPow_FOV_Forward) {
   double x1 = 0.642, x2 = 6.42, x3 = 0.528, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE(ExpPow_FOV_Forward) {
   ax1 = exp(ax1 + exp(ax2 + ax3)) * pow(ax1 + ax2, ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       std::exp(x1 + std::exp(x2 + x3)) * std::pow(x1 + x2, x3) +
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE(ExpPow_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -774,14 +774,14 @@ BOOST_AUTO_TEST_CASE(ExpPow_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(ExpPowOperator_FOV_Reverse) {
   double x1 = 1., x2 = 2., x3 = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(ExpPowOperator_FOV_Reverse) {
   ax1 = exp(ax1 + exp(ax2 + ax3)) * pow(ax1 + ax2, ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       std::exp(x1 + std::exp(x2 + x3)) * std::pow(x1 + x2, x3) +
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(ExpPowOperator_FOV_Reverse) {
   u[1][0] = -1.;
   u[2][0] = -2.;
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -837,15 +837,15 @@ BOOST_AUTO_TEST_CASE(ExpPowOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeSqrt_FOV_Forward) {
   double x1 = -2.14, x2 = -2.22, x3 = 50.05, x4 = 0.104, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
   adouble ax4;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -854,7 +854,7 @@ BOOST_AUTO_TEST_CASE(CompositeSqrt_FOV_Forward) {
   ax1 = sqrt(sqrt(ax1 * ax2 + 2 * ax3)) * ax4;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.25 * std::pow(x1 * x2 + 2 * x3, -0.75) * x2 * x4;
   double x2Derivative = 0.25 * std::pow(x1 * x2 + 2 * x3, -0.75) * x1 * x4;
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(CompositeSqrt_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 4, 4, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 4, 4, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -899,15 +899,15 @@ BOOST_AUTO_TEST_CASE(CompositeSqrt_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeSqrtOperator_FOV_Reverse) {
   double x1 = -2.14, x2 = -2.22, x3 = 50.05, x4 = 0.104, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
   adouble ax4;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE(CompositeSqrtOperator_FOV_Reverse) {
   ax1 = sqrt(sqrt(ax1 * ax2 + 2 * ax3)) * ax4;
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.25 * std::pow(x1 * x2 + 2 * x3, -0.75) * x2 * x4;
   double x2Derivative = 0.25 * std::pow(x1 * x2 + 2 * x3, -0.75) * x1 * x4;
@@ -931,7 +931,7 @@ BOOST_AUTO_TEST_CASE(CompositeSqrtOperator_FOV_Reverse) {
   u[2][0] = 2.;
   u[3][0] = -2.;
 
-  fov_reverse(tapeId, 1, 4, 4, u, z);
+  fov_reverse(*tapePtr, 1, 4, 4, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -967,15 +967,15 @@ BOOST_AUTO_TEST_CASE(CompositeSqrtOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Forward) {
   double x1 = 0.1, x2 = 5.099, x3 = 5.5, x4 = 4.73, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
   adouble ax4;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -984,7 +984,7 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Forward) {
   ax1 = tanh(acos(pow(ax1, 2) + 0.5) * sin(ax2)) * ax3 + exp(cosh(ax4));
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -(1 - std::pow(std::tanh(std::acos(std::pow(x1, 2) + 0.5) * std::sin(x2)),
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 4, 4, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 4, 4, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1038,15 +1038,15 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Reverse) {
   double x1 = 0.1, x2 = 5.099, x3 = 5.5, x4 = 4.73, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
   adouble ax4;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1055,7 +1055,7 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Reverse) {
   ax1 = tanh(acos(pow(ax1, 2) + 0.5) * sin(ax2)) * ax3 + exp(cosh(ax4));
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -(1 - std::pow(std::tanh(std::acos(std::pow(x1, 2) + 0.5) * std::sin(x2)),
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Reverse) {
   u[2][0] = -2.;
   u[3][0] = std::exp(2.);
 
-  fov_reverse(tapeId, 1, 4, 4, u, z);
+  fov_reverse(*tapePtr, 1, 4, 4, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1111,14 +1111,14 @@ BOOST_AUTO_TEST_CASE(CompositeHyperbOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Forward) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1126,7 +1126,7 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Forward) {
   ax1 = fmax(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(x3, 2) * std::exp(x3);
   double x2Derivative = 0.0;
@@ -1153,7 +1153,7 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1176,14 +1176,14 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Forward) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1191,7 +1191,7 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Forward) {
   ax1 = max(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(x3, 2) * std::exp(x3);
   double x2Derivative = 0.0;
@@ -1218,7 +1218,7 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1234,14 +1234,14 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Reverse) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1249,7 +1249,7 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Reverse) {
   ax1 = fmax(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(x3, 2) * std::exp(x3);
   double x2Derivative = 0.0;
@@ -1263,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Reverse) {
   u[1][0] = std::sqrt(5.);
   u[2][0] = -std::sqrt(10.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1282,14 +1282,14 @@ BOOST_AUTO_TEST_CASE(CompositeFmaxOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Reverse) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1297,7 +1297,7 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Reverse) {
   ax1 = max(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = std::pow(x3, 2) * std::exp(x3);
   double x2Derivative = 0.0;
@@ -1311,7 +1311,7 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Reverse) {
   u[1][0] = std::sqrt(5.);
   u[2][0] = -std::sqrt(10.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1337,14 +1337,14 @@ BOOST_AUTO_TEST_CASE(CompositeMaxOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Forward) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1352,7 +1352,7 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Forward) {
   ax1 = fmin(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.0;
   double x2Derivative = std::pow(x3, 2) * std::exp(x3);
@@ -1379,7 +1379,7 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1402,14 +1402,14 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Forward) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1417,7 +1417,7 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Forward) {
   ax1 = min(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.0;
   double x2Derivative = std::pow(x3, 2) * std::exp(x3);
@@ -1444,7 +1444,7 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1460,14 +1460,14 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Reverse) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1475,7 +1475,7 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Reverse) {
   ax1 = fmin(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.0;
   double x2Derivative = std::pow(x3, 2) * std::exp(x3);
@@ -1489,7 +1489,7 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Reverse) {
   u[1][0] = std::sqrt(6.);
   u[2][0] = -std::sqrt(3.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1508,14 +1508,14 @@ BOOST_AUTO_TEST_CASE(CompositeFminOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Reverse) {
   double x1 = 2.31, x2 = 1.32, x3 = 3.21, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1523,7 +1523,7 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Reverse) {
   ax1 = min(ax1 * pow(ax3, 2), ax2 * pow(ax3, 2)) * exp(ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative = 0.0;
   double x2Derivative = std::pow(x3, 2) * std::exp(x3);
@@ -1537,7 +1537,7 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Reverse) {
   u[1][0] = std::sqrt(6.);
   u[2][0] = -std::sqrt(3.);
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1571,8 +1571,8 @@ BOOST_AUTO_TEST_CASE(CompositeMinOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeErfFabs_FOV_Forward) {
   double x1 = 4.56, x2 = 5.46, x3 = 4.65, x4 = 6.54, x5 = 6.45, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -1580,7 +1580,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabs_FOV_Forward) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1590,7 +1590,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabs_FOV_Forward) {
   ax1 = erf(fabs(ax1 - ax2) * sinh(ax3 - ax4)) * sin(ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2. / std::sqrt(std::acos(-1.)) *
@@ -1633,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabs_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 5, 5, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 5, 5, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1666,8 +1666,8 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabs_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeErfAbs_FOV_Forward) {
   double x1 = 4.56, x2 = 5.46, x3 = 4.65, x4 = 6.54, x5 = 6.45, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -1675,7 +1675,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbs_FOV_Forward) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1685,7 +1685,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbs_FOV_Forward) {
   ax1 = erf(abs(ax1 - ax2) * sinh(ax3 - ax4)) * sin(ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2. / std::sqrt(std::acos(-1.)) *
@@ -1728,7 +1728,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbs_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 5, 5, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 5, 5, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1746,8 +1746,8 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbs_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CompositeErfFabsOperator_FOV_Reverse) {
   double x1 = 4.56, x2 = 5.46, x3 = 4.65, x4 = 6.54, x5 = 6.45, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -1755,7 +1755,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabsOperator_FOV_Reverse) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1765,7 +1765,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabsOperator_FOV_Reverse) {
   ax1 = erf(fabs(ax1 - ax2) * sinh(ax3 - ax4)) * sin(ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2. / std::sqrt(std::acos(-1.)) *
@@ -1795,7 +1795,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabsOperator_FOV_Reverse) {
   u[3][0] = 7.;
   u[4][0] = -9.;
 
-  fov_reverse(tapeId, 1, 5, 5, u, z);
+  fov_reverse(*tapePtr, 1, 5, 5, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1830,8 +1830,8 @@ BOOST_AUTO_TEST_CASE(CompositeErfFabsOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CompositeErfAbsOperator_FOV_Reverse) {
   double x1 = 4.56, x2 = 5.46, x3 = 4.65, x4 = 6.54, x5 = 6.45, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -1839,7 +1839,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbsOperator_FOV_Reverse) {
   adouble ax4;
   adouble ax5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1849,7 +1849,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbsOperator_FOV_Reverse) {
   ax1 = erf(abs(ax1 - ax2) * sinh(ax3 - ax4)) * sin(ax5);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       -2. / std::sqrt(std::acos(-1.)) *
@@ -1879,7 +1879,7 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbsOperator_FOV_Reverse) {
   u[3][0] = 7.;
   u[4][0] = -9.;
 
-  fov_reverse(tapeId, 1, 5, 5, u, z);
+  fov_reverse(*tapePtr, 1, 5, 5, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -1924,14 +1924,14 @@ BOOST_AUTO_TEST_CASE(CompositeErfAbsOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(ExpTrigSqrt_FOV_Forward) {
   double x1 = 2.1, x2 = 1.2, x3 = 0.12, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1939,7 +1939,7 @@ BOOST_AUTO_TEST_CASE(ExpTrigSqrt_FOV_Forward) {
   ax1 = 5. * exp(sin(ax1) * cos(ax1)) * pow(sqrt(ax2), ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       5. * std::exp(std::sin(x1) * std::cos(x1)) *
@@ -1970,7 +1970,7 @@ BOOST_AUTO_TEST_CASE(ExpTrigSqrt_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(*y == x1, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == x1Derivative, tt::tolerance(tol));
@@ -1986,14 +1986,14 @@ BOOST_AUTO_TEST_CASE(ExpTrigSqrt_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(ExpTrigSqrtFabsOperator_FOV_Reverse) {
   double x1 = 2.1, x2 = 1.2, x3 = 0.12, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
   adouble ax3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2001,7 +2001,7 @@ BOOST_AUTO_TEST_CASE(ExpTrigSqrtFabsOperator_FOV_Reverse) {
   ax1 = 5. * exp(sin(ax1) * cos(ax1)) * pow(sqrt(ax2), ax3);
 
   ax1 >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double x1Derivative =
       5. * std::exp(std::sin(x1) * std::cos(x1)) *
@@ -2019,7 +2019,7 @@ BOOST_AUTO_TEST_CASE(ExpTrigSqrtFabsOperator_FOV_Reverse) {
   u[1][0] = 3.;
   u[2][0] = -5.;
 
-  fov_reverse(tapeId, 1, 3, 3, u, z);
+  fov_reverse(*tapePtr, 1, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == x2Derivative, tt::tolerance(tol));
@@ -2056,8 +2056,8 @@ BOOST_AUTO_TEST_CASE(PolarCoord_FOV_Forward) {
   double x1 = 8.17, x2 = -3.41, x3 = 10.01, out1, out2, out3;
   double y1, y2, y3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2066,7 +2066,7 @@ BOOST_AUTO_TEST_CASE(PolarCoord_FOV_Forward) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2078,7 +2078,7 @@ BOOST_AUTO_TEST_CASE(PolarCoord_FOV_Forward) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* The obvious naming convention is applied here:  The derivative of
    * component yi in the direction xj is saved in yixjDerivative.
@@ -2119,7 +2119,7 @@ BOOST_AUTO_TEST_CASE(PolarCoord_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 3, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 3, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2143,8 +2143,8 @@ BOOST_AUTO_TEST_CASE(PolarCoord_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(PolarCoordOperator_FOV_Reverse) {
   double x1 = 8.17, x2 = -3.41, x3 = 10.01, out1, out2, out3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2153,7 +2153,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordOperator_FOV_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2165,7 +2165,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordOperator_FOV_Reverse) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* The obvious naming convention is applied here:  The derivative of
    * component yi in the direction xj is saved in yixjDerivative.
@@ -2195,7 +2195,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 3, 3, 3, u, z);
+  fov_reverse(*tapePtr, 3, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));
@@ -2224,8 +2224,8 @@ BOOST_AUTO_TEST_CASE(SimpleProd_FOV_Forward) {
   double x1 = 2.52, x2 = 5.22, x3 = -2.25, out1, out2, out3;
   double y1, y2, y3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2234,7 +2234,7 @@ BOOST_AUTO_TEST_CASE(SimpleProd_FOV_Forward) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2246,7 +2246,7 @@ BOOST_AUTO_TEST_CASE(SimpleProd_FOV_Forward) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.0;
   double y1x2Derivative = x3;
@@ -2280,7 +2280,7 @@ BOOST_AUTO_TEST_CASE(SimpleProd_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 3, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 3, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2304,8 +2304,8 @@ BOOST_AUTO_TEST_CASE(SimpleProd_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SimpleProdOperator_FOV_Reverse) {
   double x1 = 2.52, x2 = 5.22, x3 = -2.25, out1, out2, out3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2314,7 +2314,7 @@ BOOST_AUTO_TEST_CASE(SimpleProdOperator_FOV_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2326,7 +2326,7 @@ BOOST_AUTO_TEST_CASE(SimpleProdOperator_FOV_Reverse) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.0;
   double y1x2Derivative = x3;
@@ -2350,7 +2350,7 @@ BOOST_AUTO_TEST_CASE(SimpleProdOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 3, 3, 3, u, z);
+  fov_reverse(*tapePtr, 3, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));
@@ -2379,8 +2379,8 @@ BOOST_AUTO_TEST_CASE(SimpleSum_FOV_Forward) {
   double x1 = 2.52, x2 = 5.22, x3 = -2.25, out1, out2, out3;
   double y1, y2, y3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2389,7 +2389,7 @@ BOOST_AUTO_TEST_CASE(SimpleSum_FOV_Forward) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2401,7 +2401,7 @@ BOOST_AUTO_TEST_CASE(SimpleSum_FOV_Forward) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.0;
   double y1x2Derivative = 1.0;
@@ -2435,7 +2435,7 @@ BOOST_AUTO_TEST_CASE(SimpleSum_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 3, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 3, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2459,8 +2459,8 @@ BOOST_AUTO_TEST_CASE(SimpleSum_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SimpleSumOperator_FOV_Reverse) {
   double x1 = 2.52, x2 = 5.22, x3 = -2.25, out1, out2, out3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2469,7 +2469,7 @@ BOOST_AUTO_TEST_CASE(SimpleSumOperator_FOV_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2481,7 +2481,7 @@ BOOST_AUTO_TEST_CASE(SimpleSumOperator_FOV_Reverse) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.0;
   double y1x2Derivative = 1.0;
@@ -2505,7 +2505,7 @@ BOOST_AUTO_TEST_CASE(SimpleSumOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 3, 3, 3, u, z);
+  fov_reverse(*tapePtr, 3, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));
@@ -2540,8 +2540,8 @@ BOOST_AUTO_TEST_CASE(TrigProd_FOV_Forward) {
   double x1 = 5.5, x2 = 0.5, x3 = 5.55, x4 = 2.33, out1, out2, out3, out4;
   double y1, y2, y3, y4;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2552,7 +2552,7 @@ BOOST_AUTO_TEST_CASE(TrigProd_FOV_Forward) {
   adouble ay3;
   adouble ay4;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2567,7 +2567,7 @@ BOOST_AUTO_TEST_CASE(TrigProd_FOV_Forward) {
   ay2 >>= out2;
   ay3 >>= out3;
   ay4 >>= out4;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2);
   double y1x2Derivative = -x1 * std::sin(x2);
@@ -2614,7 +2614,7 @@ BOOST_AUTO_TEST_CASE(TrigProd_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 4, 4, 4, x, xd, y, yd);
+  fov_forward(*tapePtr, 4, 4, 4, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2646,8 +2646,8 @@ BOOST_AUTO_TEST_CASE(TrigProd_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(TrigProdOperator_FOV_Reverse) {
   double x1 = 5.5, x2 = 0.5, x3 = 5.55, x4 = 2.33, out1, out2, out3, out4;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2658,7 +2658,7 @@ BOOST_AUTO_TEST_CASE(TrigProdOperator_FOV_Reverse) {
   adouble ay3;
   adouble ay4;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2673,7 +2673,7 @@ BOOST_AUTO_TEST_CASE(TrigProdOperator_FOV_Reverse) {
   ay2 >>= out2;
   ay3 >>= out3;
   ay4 >>= out4;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2);
   double y1x2Derivative = -x1 * std::sin(x2);
@@ -2708,7 +2708,7 @@ BOOST_AUTO_TEST_CASE(TrigProdOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 4, 4, 4, u, z);
+  fov_reverse(*tapePtr, 4, 4, 4, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));
@@ -2746,8 +2746,8 @@ BOOST_AUTO_TEST_CASE(PolarCoordInv_FOV_Forward) {
   double x1 = 4.21, x2 = -0.98, x3 = 3.02, out1, out2, out3;
   double y1, y2, y3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2756,7 +2756,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInv_FOV_Forward) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2768,7 +2768,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInv_FOV_Forward) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2) * std::sin(x3);
   double y1x2Derivative = -x1 * std::sin(x2) * std::sin(x3);
@@ -2802,7 +2802,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInv_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 3, 3, 3, x, xd, y, yd);
+  fov_forward(*tapePtr, 3, 3, 3, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2826,8 +2826,8 @@ BOOST_AUTO_TEST_CASE(PolarCoordInv_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(PolarCoordInvProdOperator_FOV_Reverse) {
   double x1 = 4.21, x2 = -0.98, x3 = 3.02, out1, out2, out3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2836,7 +2836,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInvProdOperator_FOV_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2848,7 +2848,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInvProdOperator_FOV_Reverse) {
   ay1 >>= out1;
   ay2 >>= out2;
   ay3 >>= out3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2) * std::sin(x3);
   double y1x2Derivative = -x1 * std::sin(x2) * std::sin(x3);
@@ -2872,7 +2872,7 @@ BOOST_AUTO_TEST_CASE(PolarCoordInvProdOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 3, 3, 3, u, z);
+  fov_reverse(*tapePtr, 3, 3, 3, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));
@@ -2906,8 +2906,8 @@ BOOST_AUTO_TEST_CASE(MultiHyperb_FOV_Forward) {
   double x1 = 1., x2 = 0.1, out1, out2, out3, out4;
   double y1, y2, y3, y4;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -2916,7 +2916,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperb_FOV_Forward) {
   adouble ay3;
   adouble ay4;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ax1 <<= x1;
   ax2 <<= x2;
 
@@ -2929,7 +2929,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperb_FOV_Forward) {
   ay2 >>= out2;
   ay3 >>= out3;
   ay4 >>= out4;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative =
       2. * x1 * std::cosh(x1 * x1) * std::cosh(x2 * x2 * x2);
@@ -2968,7 +2968,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperb_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 4, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 4, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(y[0] == y1, tt::tolerance(tol));
   BOOST_TEST(y[1] == y2, tt::tolerance(tol));
@@ -2992,8 +2992,8 @@ BOOST_AUTO_TEST_CASE(MultiHyperb_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(MultiHyperbProdOperator_FOV_Reverse) {
   double x1 = 1., x2 = 0.1, out1, out2, out3, out4;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ax1;
   adouble ax2;
@@ -3002,7 +3002,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperbProdOperator_FOV_Reverse) {
   adouble ay3;
   adouble ay4;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
@@ -3015,7 +3015,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperbProdOperator_FOV_Reverse) {
   ay2 >>= out2;
   ay3 >>= out3;
   ay4 >>= out4;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative =
       2. * x1 * std::cosh(x1 * x1) * std::cosh(x2 * x2 * x2);
@@ -3043,7 +3043,7 @@ BOOST_AUTO_TEST_CASE(MultiHyperbProdOperator_FOV_Reverse) {
     }
   }
 
-  fov_reverse(tapeId, 4, 2, 4, u, z);
+  fov_reverse(*tapePtr, 4, 2, 4, u, z);
 
   BOOST_TEST(z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == y1x2Derivative, tt::tolerance(tol));

--- a/ADOL-C/boost-test/traceFixedPointScalarTests.cpp
+++ b/ADOL-C/boost-test/traceFixedPointScalarTests.cpp
@@ -96,7 +96,6 @@ BOOST_AUTO_TEST_CASE(NewtonScalarFixedPoint_zos_forward) {
   BOOST_TEST(value[0] == sqrt(argument[0]), tt::tolerance(tol));
 }
 
-
 BOOST_AUTO_TEST_CASE(NewtonScalarFixedPoint_fos_forward) {
   fpi_stack_clear();
   // Compute the square root of 2.0
@@ -112,10 +111,8 @@ BOOST_AUTO_TEST_CASE(NewtonScalarFixedPoint_fos_forward) {
   double value[1];
   double derivative[1];
 
-
   const double tangent[1] = {1.0};
 
-  
   fos_forward(*outerTapePtr, // Tape number
               1,             // Number of dependent variables
               1,             // Number of independent variables,

--- a/ADOL-C/boost-test/traceOperatorScalar.cpp
+++ b/ADOL-C/boost-test/traceOperatorScalar.cpp
@@ -1,3 +1,6 @@
+#include "adolc/tape_interface.h"
+#include "adolc/valuetape/valuetape.h"
+#include <memory>
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -25,18 +28,18 @@ BOOST_AUTO_TEST_SUITE(trace_scalar)
  */
 BOOST_AUTO_TEST_CASE(ExpOperator_ZOS_Forward) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ad;
   double a = 2., aout;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = exp(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::exp(a);
 
@@ -47,7 +50,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_ZOS_Forward) {
 
   *x = 2.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -57,18 +60,18 @@ BOOST_AUTO_TEST_CASE(ExpOperator_ZOS_Forward) {
 
 BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Forward) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   double a = 2., aout;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   ad = exp(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::exp(a);
   a = std::exp(a);
@@ -81,7 +84,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Forward) {
   *x = 2.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -94,20 +97,20 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Forward) {
 
 BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Reverse) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
   double a = 2., aout;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = exp(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::exp(a);
 
@@ -116,7 +119,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -126,22 +129,22 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(MultOperator_ZOS_Forward) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
   double a = 2., b = 3.5, out;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad * bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a * b;
 
@@ -154,7 +157,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_ZOS_Forward) {
   *x = 2.;
   *(x + 1) = 3.5;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -164,20 +167,20 @@ BOOST_AUTO_TEST_CASE(MultOperator_ZOS_Forward) {
 
 BOOST_AUTO_TEST_CASE(MultOperator_FOS_Forward) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad, bd;
   double a = 2., b = 3.5, out;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad * bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -194,7 +197,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOS_Forward) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -203,7 +206,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOS_Forward) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -215,22 +218,22 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOS_Forward) {
 
 BOOST_AUTO_TEST_CASE(MultOperator_FOS_Reverse) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
   double a = 2., b = 3.5, out;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad * bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -240,7 +243,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -252,20 +255,20 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AddOperator_ZOS_Forward) {
   double a = 2.5, b = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad + bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a + b;
 
@@ -277,7 +280,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_ZOS_Forward) {
   *x = 2.5;
   *(x + 1) = 3.;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -288,20 +291,20 @@ BOOST_AUTO_TEST_CASE(AddOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AddOperator_FOS_Forward) {
   double a = 2.5, b = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad + bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -318,7 +321,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOS_Forward) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -327,7 +330,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOS_Forward) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -340,20 +343,20 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AddOperator_FOS_Reverse) {
   double a = 2.5, b = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad + bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -363,7 +366,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -375,20 +378,20 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SubOperator_ZOS_Forward) {
   double a = 1.5, b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad - bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a - b;
 
@@ -400,7 +403,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_ZOS_Forward) {
   *x = 1.5;
   *(x + 1) = 3.2;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -411,20 +414,20 @@ BOOST_AUTO_TEST_CASE(SubOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SubOperator_FOS_Forward) {
   double a = 1.5, b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad - bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -441,7 +444,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOS_Forward) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -450,7 +453,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOS_Forward) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -463,20 +466,20 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SubOperator_FOS_Reverse) {
   double a = 1.5, b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad - bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -486,7 +489,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -498,20 +501,20 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(DivOperator_ZOS_Forward) {
   double a = 0.5, b = 4.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad / bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a / b;
 
@@ -523,7 +526,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_ZOS_Forward) {
   *x = 0.5;
   *(x + 1) = 4.5;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -534,20 +537,20 @@ BOOST_AUTO_TEST_CASE(DivOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(DivOperator_FOS_Forward) {
   double a = 0.5, b = 4.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad / bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -564,7 +567,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOS_Forward) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -573,7 +576,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOS_Forward) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -586,20 +589,20 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(DivOperator_FOS_Reverse) {
   double a = 0.5, b = 4.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad / bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -609,7 +612,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -621,18 +624,18 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(TanOperator_ZOS_Forward) {
   double a = 0.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tan(a);
 
@@ -643,7 +646,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_ZOS_Forward) {
 
   *x = 0.7;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -654,18 +657,18 @@ BOOST_AUTO_TEST_CASE(TanOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(TanOperator_FOS_Forward) {
   double a = 0.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tan(a);
   double aDerivative = 1. + a * a;
@@ -678,7 +681,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOS_Forward) {
   *x = 0.7;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -692,18 +695,18 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(TanOperator_FOS_Reverse) {
   double a = 0.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = tan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tan(a);
   double aDerivative = 1. + a * a;
@@ -713,7 +716,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -724,18 +727,18 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SinOperator_ZOS_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sin(a);
 
@@ -746,7 +749,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_ZOS_Forward) {
 
   *x = 1.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -757,18 +760,18 @@ BOOST_AUTO_TEST_CASE(SinOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SinOperator_FOS_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cos(a);
   a = std::sin(a);
@@ -781,7 +784,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOS_Forward) {
   *x = 1.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -795,18 +798,18 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SinOperator_FOS_Reverse) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cos(a);
   a = std::sin(a);
@@ -816,7 +819,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -827,18 +830,18 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(CosOperator_ZOS_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::cos(a);
 
@@ -849,7 +852,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_ZOS_Forward) {
 
   *x = 1.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -860,18 +863,18 @@ BOOST_AUTO_TEST_CASE(CosOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CosOperator_FOS_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -std::sin(a);
   a = std::cos(a);
@@ -884,7 +887,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOS_Forward) {
   *x = 1.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -898,18 +901,18 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(CosOperator_FOS_Reverse) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -std::sin(a);
   a = std::cos(a);
@@ -919,7 +922,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -930,18 +933,18 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SqrtOperator_ZOS_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sqrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sqrt(a);
 
@@ -952,7 +955,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_ZOS_Forward) {
 
   *x = 2.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -963,18 +966,18 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sqrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sqrt(a);
   double aDerivative = 1. / (2 * a);
@@ -987,7 +990,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Forward) {
   *x = 2.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1001,18 +1004,18 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Reverse) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sqrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sqrt(a);
   double aDerivative = 1. / (2 * a);
@@ -1022,7 +1025,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1033,19 +1036,19 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(CbrtOperator_ZOS_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   // cbrt(a)
   ad = cbrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   // cbrt(a)
   a = std::cbrt(a);
@@ -1057,7 +1060,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_ZOS_Forward) {
 
   *x = 2.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1068,19 +1071,19 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   // cbrt(a)
   ad = cbrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   // cbrt(a)
   const double out = std::cbrt(a);
@@ -1096,7 +1099,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Forward) {
   *x = 2.2;
   *xd = 1.1;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == out, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative * xd[0], tt::tolerance(tol));
@@ -1110,19 +1113,19 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Reverse) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
   // cbrt(a)
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cbrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   // 1 / 3 * a^(-2/3)
   double aDerivative = 1. / (3.0 * std::pow(a, 2.0 / 3.0));
@@ -1132,7 +1135,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Reverse) {
 
   *u = 1.1;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == u[0] * aDerivative, tt::tolerance(tol));
 
@@ -1143,18 +1146,18 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(LogOperator_ZOS_Forward) {
   double a = 4.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::log(a);
 
@@ -1165,7 +1168,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_ZOS_Forward) {
 
   *x = 4.9;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1176,18 +1179,18 @@ BOOST_AUTO_TEST_CASE(LogOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(LogOperator_FOS_Forward) {
   double a = 4.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / a;
   a = std::log(a);
@@ -1200,7 +1203,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOS_Forward) {
   *x = 4.9;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1214,18 +1217,18 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(LogOperator_FOS_Reverse) {
   double a = 4.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = log(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / a;
   a = std::log(a);
@@ -1235,7 +1238,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1246,18 +1249,18 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SinhOperator_ZOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sinh(a);
 
@@ -1268,7 +1271,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_ZOS_Forward) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1279,18 +1282,18 @@ BOOST_AUTO_TEST_CASE(SinhOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cosh(a);
   a = std::sinh(a);
@@ -1303,7 +1306,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Forward) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1317,18 +1320,18 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cosh(a);
   a = std::sinh(a);
@@ -1338,7 +1341,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1349,18 +1352,18 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(CoshOperator_ZOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::cosh(a);
 
@@ -1371,7 +1374,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_ZOS_Forward) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1382,18 +1385,18 @@ BOOST_AUTO_TEST_CASE(CoshOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::sinh(a);
   a = std::cosh(a);
@@ -1406,7 +1409,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Forward) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1420,18 +1423,18 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::sinh(a);
   a = std::cosh(a);
@@ -1441,7 +1444,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1452,18 +1455,18 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(TanhOperator_ZOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tanh(a);
 
@@ -1474,7 +1477,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_ZOS_Forward) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1485,18 +1488,18 @@ BOOST_AUTO_TEST_CASE(TanhOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tanh(a);
   double aDerivative = 1. - a * a;
@@ -1509,7 +1512,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Forward) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1523,18 +1526,18 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = tanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tanh(a);
   double aDerivative = 1. - a * a;
@@ -1544,7 +1547,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1555,18 +1558,18 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AsinOperator_ZOS_Forward) {
   double a = 0.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::asin(a);
 
@@ -1577,7 +1580,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_ZOS_Forward) {
 
   *x = 0.9;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1588,18 +1591,18 @@ BOOST_AUTO_TEST_CASE(AsinOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Forward) {
   double a = 0.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(1. - a * a));
   a = std::asin(a);
@@ -1612,7 +1615,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Forward) {
   *x = 0.9;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1626,18 +1629,18 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Reverse) {
   double a = 0.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = asin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(1. - a * a));
   a = std::asin(a);
@@ -1647,7 +1650,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1658,18 +1661,18 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AcosOperator_ZOS_Forward) {
   double a = 0.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::acos(a);
 
@@ -1680,7 +1683,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_ZOS_Forward) {
 
   *x = 0.8;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1691,18 +1694,18 @@ BOOST_AUTO_TEST_CASE(AcosOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Forward) {
   double a = 0.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1. / (std::sqrt(1. - a * a));
   a = std::acos(a);
@@ -1715,7 +1718,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Forward) {
   *x = 0.8;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1729,18 +1732,18 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Reverse) {
   double a = 0.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = acos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1. / (std::sqrt(1. - a * a));
   a = std::acos(a);
@@ -1750,7 +1753,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1761,18 +1764,18 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AtanOperator_ZOS_Forward) {
   double a = 9.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::atan(a);
 
@@ -1783,7 +1786,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_ZOS_Forward) {
 
   *x = 9.8;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1794,18 +1797,18 @@ BOOST_AUTO_TEST_CASE(AtanOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Forward) {
   double a = 9.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. + a * a);
   a = std::atan(a);
@@ -1818,7 +1821,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Forward) {
   *x = 9.8;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1832,18 +1835,18 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Reverse) {
   double a = 9.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = atan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. + a * a);
   a = std::atan(a);
@@ -1853,7 +1856,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1864,18 +1867,18 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(Log10Operator_ZOS_Forward) {
   double a = 12.3, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log10(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::log10(a);
 
@@ -1886,7 +1889,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_ZOS_Forward) {
 
   *x = 12.3;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -1897,18 +1900,18 @@ BOOST_AUTO_TEST_CASE(Log10Operator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Forward) {
   double a = 12.3, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log10(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (a * std::log(10));
   a = std::log10(a);
@@ -1921,7 +1924,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Forward) {
   *x = 12.3;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -1935,18 +1938,18 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Reverse) {
   double a = 12.3, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = log10(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (a * std::log(10));
   a = std::log10(a);
@@ -1956,7 +1959,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -1967,18 +1970,18 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AsinhOperator_ZOS_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::asinh(a);
 
@@ -1989,7 +1992,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_ZOS_Forward) {
 
   *x = 0.6;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2000,18 +2003,18 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a + 1.));
   a = std::asinh(a);
@@ -2024,7 +2027,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Forward) {
   *x = 0.6;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2038,18 +2041,18 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Reverse) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = asinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a + 1.));
   a = std::asinh(a);
@@ -2059,7 +2062,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2070,18 +2073,18 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AcoshOperator_ZOS_Forward) {
   double a = 1.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::acosh(a);
 
@@ -2092,7 +2095,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_ZOS_Forward) {
 
   *x = 1.7;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2103,18 +2106,18 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Forward) {
   double a = 1.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a - 1));
   a = std::acosh(a);
@@ -2127,7 +2130,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Forward) {
   *x = 1.7;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2141,18 +2144,18 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Reverse) {
   double a = 1.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = acosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a - 1.));
   a = std::acosh(a);
@@ -2162,7 +2165,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2173,18 +2176,18 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(AtanhOperator_ZOS_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::atanh(a);
 
@@ -2195,7 +2198,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_ZOS_Forward) {
 
   *x = 0.6;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2206,18 +2209,18 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. - a * a);
   a = std::atanh(a);
@@ -2230,7 +2233,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Forward) {
   *x = 0.6;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2244,18 +2247,18 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Reverse) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = atanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. - a * a);
   a = std::atanh(a);
@@ -2265,7 +2268,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2276,18 +2279,18 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(InclOperator_ZOS_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ++ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   ++a;
 
@@ -2298,7 +2301,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_ZOS_Forward) {
 
   *x = 5.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2309,18 +2312,18 @@ BOOST_AUTO_TEST_CASE(InclOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(InclOperator_FOS_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ++ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   ++a;
@@ -2333,7 +2336,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOS_Forward) {
   *x = 5.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2347,18 +2350,18 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(InclOperator_FOS_Reverse) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ++ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   ++a;
@@ -2368,7 +2371,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2379,18 +2382,18 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(DeclOperator_ZOS_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   --ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   --a;
 
@@ -2401,7 +2404,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_ZOS_Forward) {
 
   *x = 5.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2412,18 +2415,18 @@ BOOST_AUTO_TEST_CASE(DeclOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   --ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   --a;
@@ -2436,7 +2439,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Forward) {
   *x = 5.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2450,18 +2453,18 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Reverse) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   --ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   --a;
@@ -2471,7 +2474,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2482,18 +2485,18 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SignPlusOperator_ZOS_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = +ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = +a;
 
@@ -2504,7 +2507,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_ZOS_Forward) {
 
   *x = 1.5;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2515,18 +2518,18 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = +ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = +a;
@@ -2539,7 +2542,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Forward) {
   *x = 1.5;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2553,18 +2556,18 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Reverse) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = +ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = +a;
@@ -2574,7 +2577,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2585,18 +2588,18 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(SignMinusOperator_ZOS_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = -ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = -a;
 
@@ -2607,7 +2610,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_ZOS_Forward) {
 
   *x = 1.5;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2618,18 +2621,18 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = -ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
   a = -a;
@@ -2642,7 +2645,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Forward) {
   *x = 1.5;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2656,18 +2659,18 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Reverse) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = -ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
   a = -a;
@@ -2677,7 +2680,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2688,20 +2691,20 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(Atan2Operator_ZOS_Forward) {
   double a = 12.3, b = 2.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = atan2(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::atan2(a, b);
 
@@ -2713,7 +2716,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_ZOS_Forward) {
   *x = 12.3;
   *(x + 1) = 2.1;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2724,20 +2727,20 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Forward) {
   double a = 12.3, b = 2.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = atan2(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b / (a * a + b * b);
   double bDerivative = -a / (a * a + b * b);
@@ -2754,7 +2757,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Forward) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2763,7 +2766,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Forward) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -2776,20 +2779,20 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Reverse) {
   double a = 12.3, b = 2.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = atan2(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b / (a * a + b * b);
   double bDerivative = -a / (a * a + b * b);
@@ -2799,7 +2802,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -2811,18 +2814,18 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_1) {
   double a = 2.3, e = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = pow(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::pow(a, e);
 
@@ -2833,7 +2836,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_1) {
 
   *x = 2.3;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2844,18 +2847,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_1) {
   double a = 2.3, e = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = pow(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = e * std::pow(a, e - 1.);
   a = std::pow(a, e);
@@ -2868,7 +2871,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_1) {
   *x = 2.3;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2884,18 +2887,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_1)
   double a = 2.3, e = 3.5, aout;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = pow(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = e * std::pow(a, e - 1.);
   a = std::pow(a, e);
@@ -2905,7 +2908,7 @@ setCurrentTape(tapeId);
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -2916,20 +2919,20 @@ setCurrentTape(tapeId);
 BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_2) {
   double a = 2.3, b = 3.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = pow(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::pow(a, b);
 
@@ -2941,7 +2944,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_2) {
   *x = 2.3;
   *(x + 1) = 3.5;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -2952,20 +2955,20 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_2) {
   double a = 2.3, b = 3.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = pow(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b * std::pow(a, b - 1.);
   double bDerivative = std::log(a) * std::pow(a, b);
@@ -2982,7 +2985,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_2) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -2991,7 +2994,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_2) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -3004,20 +3007,20 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_2) {
   double a = 2.3, b = 3.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = pow(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b * std::pow(a, b - 1.);
   double bDerivative = std::log(a) * std::pow(a, b);
@@ -3027,7 +3030,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -3039,18 +3042,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_3) {
   double a = 2.3, e = 3.5, eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= e;
 
   ad = pow(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   e = std::pow(a, e);
 
@@ -3061,7 +3064,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_3) {
 
   *x = 3.5;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == e, tt::tolerance(tol));
 
@@ -3072,18 +3075,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_ZOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_3) {
   double a = 2.3, e = 3.5, eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= e;
 
   ad = pow(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aderivative = std::log(a) * std::pow(a, e);
   e = std::pow(a, e);
@@ -3096,7 +3099,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_3) {
   *x = 3.5;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == e, tt::tolerance(tol));
   BOOST_TEST(*yd == aderivative, tt::tolerance(tol));
@@ -3110,18 +3113,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_3) {
   double a = 2.3, e = 3.5, eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= e;
 
   ad = pow(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aderivative = std::log(a) * std::pow(a, e);
   e = std::pow(a, e);
@@ -3131,7 +3134,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOS_Reverse_3) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aderivative, tt::tolerance(tol));
 
@@ -3146,20 +3149,20 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_ZOS_Forward_1)
   double a = 4., b = 3., out;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
 
  adouble
 ad; adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ldexp(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a * std::pow(2., b);
 
@@ -3171,7 +3174,7 @@ ad; adouble bd;
   *x = 4.;
   *(x + 1) = 3.;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -3184,19 +3187,19 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Forward_1)
   double a = 4., b = 3., out;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
  adouble
 ad; adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ldexp(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., b);
   double bDerivative = a * std::log(2.) * std::pow(2., b);
@@ -3212,7 +3215,7 @@ ad; adouble bd;
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -3220,7 +3223,7 @@ ad; adouble bd;
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -3235,19 +3238,19 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Reverse_1)
   double a = 4., b = 3., out;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
  adouble
 ad; adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ldexp(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., b);
   double bDerivative = a * std::log(2.) * std::pow(2., b);
@@ -3257,7 +3260,7 @@ ad; adouble bd;
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -3269,18 +3272,18 @@ ad; adouble bd;
 BOOST_AUTO_TEST_CASE(LdexpOperator_ZOS_Forward_2) {
   double a = 4., aout;
   int e = 3;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ldexp(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = a * std::pow(2., e);
 
@@ -3291,7 +3294,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_ZOS_Forward_2) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -3302,18 +3305,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Forward_2) {
   double a = 4., aout;
   int e = 3;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ldexp(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., e);
   a = a * std::pow(2., e);
@@ -3326,7 +3329,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Forward_2) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -3341,18 +3344,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Reverse_2) {
   double a = 4., aout;
   int e = 3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = ldexp(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., e);
   a = a * std::pow(2., e);
@@ -3362,7 +3365,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3375,18 +3378,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_ZOS_Forward_3)
   double a = 4., e = 3., eout;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= e;
 
   ad = ldexp(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   e = a * std::pow(2., e);
 
@@ -3397,7 +3400,7 @@ setCurrentTape(tapeId);
 
   *x = 3.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == e, tt::tolerance(tol));
 
@@ -3410,18 +3413,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Forward_3)
   double a = 4., e = 3., eout;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= e;
 
   ad = ldexp(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aderivative = a * std::log(2.) * std::pow(2., e);
   e = std::pow(a, e);
@@ -3434,7 +3437,7 @@ setCurrentTape(tapeId);
   *x = 3.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == e, tt::tolerance(tol));
   BOOST_TEST(*yd == aderivative, tt::tolerance(tol));
@@ -3450,18 +3453,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOS_Reverse_3)
   double a = 4., e = 3., eout;
 
 
-const auto tapeId = createNewTape();
-setCurrentTape(tapeId);
+auto tapePtr = std::make_unique<ValueTape>();
+setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= e;
 
   ad = ldexp(a, ad);
 
   ad >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aderivative = a * std::log(2.) * std::pow(2., e);
   e = a * std::pow(2., e);
@@ -3471,7 +3474,7 @@ setCurrentTape(tapeId);
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aderivative, tt::tolerance(tol));
 
@@ -3483,18 +3486,18 @@ setCurrentTape(tapeId);
 BOOST_AUTO_TEST_CASE(FabsOperator_ZOS_Forward) {
   double a = 1.4, b = -5., c = 0., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::fabs(a);
   b = std::fabs(b);
@@ -3513,9 +3516,9 @@ BOOST_AUTO_TEST_CASE(FabsOperator_ZOS_Forward) {
   *x2 = -5.;
   *x3 = 0.;
 
-  zos_forward(tapeId, 1, 1, 0, x1, y1);
-  zos_forward(tapeId, 1, 1, 0, x2, y2);
-  zos_forward(tapeId, 1, 1, 0, x3, y3);
+  zos_forward(*tapePtr, 1, 1, 0, x1, y1);
+  zos_forward(*tapePtr, 1, 1, 0, x2, y2);
+  zos_forward(*tapePtr, 1, 1, 0, x3, y3);
 
   BOOST_TEST(*y1 == a, tt::tolerance(tol));
   BOOST_TEST(*y2 == b, tt::tolerance(tol));
@@ -3532,18 +3535,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Forward) {
   double a = 1.4, b = -5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -3564,8 +3567,8 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Forward) {
   *x2 = -5.;
   *xd2 = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
-  fos_forward(tapeId, 1, 1, 0, x2, xd2, y2, yd2);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x2, xd2, y2, yd2);
 
   BOOST_TEST(*y1 == a, tt::tolerance(tol));
   BOOST_TEST(*yd1 == aDerivative, tt::tolerance(tol));
@@ -3582,12 +3585,12 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Forward) {
   *xd3_1 = 2.5;
   *xd3_2 = -3.5;
 
-  fos_forward(tapeId, 1, 1, 0, x3, xd3_1, y3, yd3);
+  fos_forward(*tapePtr, 1, 1, 0, x3, xd3_1, y3, yd3);
 
   BOOST_TEST(*y3 == 0.0, tt::tolerance(tol));
   BOOST_TEST(*yd3 == 2.5, tt::tolerance(tol));
 
-  fos_forward(tapeId, 1, 1, 0, x3, xd3_2, y3, yd3);
+  fos_forward(*tapePtr, 1, 1, 0, x3, xd3_2, y3, yd3);
 
   BOOST_TEST(*y3 == 0.0, tt::tolerance(tol));
   BOOST_TEST(*yd3 == 3.5, tt::tolerance(tol));
@@ -3610,18 +3613,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Pos) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -3630,7 +3633,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Pos) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3641,18 +3644,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Pos) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Neg) {
   double a = -5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
 
@@ -3661,7 +3664,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Neg) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3672,18 +3675,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Neg) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Zero) {
   double a = 0., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* In reverse mode, the derivative at zero is calculatad to be zero. */
   double aDerivative = 0.;
@@ -3693,7 +3696,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Zero) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3704,18 +3707,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOS_Reverse_Zero) {
 BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_Forward) {
   double a = 1.4, b = -5., c = 0., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::abs(a);
   b = std::abs(b);
@@ -3734,9 +3737,9 @@ BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_Forward) {
   *x2 = -5.;
   *x3 = 0.;
 
-  zos_forward(tapeId, 1, 1, 0, x1, y1);
-  zos_forward(tapeId, 1, 1, 0, x2, y2);
-  zos_forward(tapeId, 1, 1, 0, x3, y3);
+  zos_forward(*tapePtr, 1, 1, 0, x1, y1);
+  zos_forward(*tapePtr, 1, 1, 0, x2, y2);
+  zos_forward(*tapePtr, 1, 1, 0, x3, y3);
 
   BOOST_TEST(*y1 == a, tt::tolerance(tol));
   BOOST_TEST(*y2 == b, tt::tolerance(tol));
@@ -3753,18 +3756,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Forward) {
   double a = 1.4, b = -5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -3785,8 +3788,8 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Forward) {
   *x2 = -5.;
   *xd2 = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
-  fos_forward(tapeId, 1, 1, 0, x2, xd2, y2, yd2);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x2, xd2, y2, yd2);
 
   BOOST_TEST(*y1 == a, tt::tolerance(tol));
   BOOST_TEST(*yd1 == aDerivative, tt::tolerance(tol));
@@ -3803,12 +3806,12 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Forward) {
   *xd3_1 = 2.5;
   *xd3_2 = -3.5;
 
-  fos_forward(tapeId, 1, 1, 0, x3, xd3_1, y3, yd3);
+  fos_forward(*tapePtr, 1, 1, 0, x3, xd3_1, y3, yd3);
 
   BOOST_TEST(*y3 == 0.0, tt::tolerance(tol));
   BOOST_TEST(*yd3 == 2.5, tt::tolerance(tol));
 
-  fos_forward(tapeId, 1, 1, 0, x3, xd3_2, y3, yd3);
+  fos_forward(*tapePtr, 1, 1, 0, x3, xd3_2, y3, yd3);
 
   BOOST_TEST(*y3 == 0.0, tt::tolerance(tol));
   BOOST_TEST(*yd3 == 3.5, tt::tolerance(tol));
@@ -3831,18 +3834,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Pos) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -3851,7 +3854,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Pos) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3862,18 +3865,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Pos) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Neg) {
   double a = -5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
 
@@ -3882,7 +3885,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Neg) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3893,18 +3896,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Neg) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Zero) {
   double a = 0., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* In reverse mode, the derivative at zero is calculatad to be zero. */
   double aDerivative = 0.;
@@ -3914,7 +3917,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Zero) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -3925,18 +3928,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOS_Reverse_Zero) {
 BOOST_AUTO_TEST_CASE(CeilOperator_ZOS_Forward) {
   double a = 3.573, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::ceil(a);
 
@@ -3947,7 +3950,7 @@ BOOST_AUTO_TEST_CASE(CeilOperator_ZOS_Forward) {
 
   *x = 3.573;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -3958,18 +3961,18 @@ BOOST_AUTO_TEST_CASE(CeilOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Forward) {
   double a = 3.573, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::ceil(a);
@@ -3982,7 +3985,7 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Forward) {
   *x = 3.573;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -3996,18 +3999,18 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Reverse) {
   double a = 3.573, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -4016,7 +4019,7 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -4027,18 +4030,18 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(FloorOperator_ZOS_Forward) {
   double a = 4.483, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = floor(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::floor(a);
 
@@ -4049,7 +4052,7 @@ BOOST_AUTO_TEST_CASE(FloorOperator_ZOS_Forward) {
 
   *x = 4.483;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -4060,18 +4063,18 @@ BOOST_AUTO_TEST_CASE(FloorOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Forward) {
   double a = 4.483, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = floor(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::floor(a);
@@ -4084,7 +4087,7 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Forward) {
   *x = 4.483;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -4098,18 +4101,18 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Reverse) {
   double a = 4.483, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -4118,7 +4121,7 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -4129,20 +4132,20 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::fmax(a, b);
 
@@ -4154,7 +4157,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_1) {
   *x = 4.;
   *(x + 1) = 3.2;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -4165,20 +4168,20 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -4195,7 +4198,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_1) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -4204,7 +4207,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_1) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -4224,7 +4227,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_1) {
   *xd1 = 1.3;
   *(xd1 + 1) = 3.7;
 
-  fos_forward(tapeId, 1, 2, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 2, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == 2.5, tt::tolerance(tol));
   BOOST_TEST(*yd1 == 3.7, tt::tolerance(tol));
@@ -4238,20 +4241,20 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -4261,7 +4264,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -4275,21 +4278,21 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_1) {
   adouble ad1;
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
   bd1 <<= b1;
 
   ad1 = fmax(ad1, bd1);
 
   ad1 >>= out1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *u1 = myalloc1(1);
   double *z1 = myalloc1(2);
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 2, u1, z1);
+  fos_reverse(*tapePtr, 1, 2, u1, z1);
 
   BOOST_TEST(*z1 == 0.5, tt::tolerance(tol));
   BOOST_TEST(*(z1 + 1) == 0.5, tt::tolerance(tol));
@@ -4301,18 +4304,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   b = std::fmax(a, b);
 
@@ -4323,7 +4326,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_2) {
 
   *x = 3.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
 
@@ -4334,18 +4337,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 0.0, as the active variable is smaller than the passive
    * one. */
@@ -4360,7 +4363,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
   *x = 3.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
@@ -4375,13 +4378,13 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
 
   adouble bd1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd1 <<= b1;
 
   bd1 = fmax(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.;
   b1 = std::fmax(a1, b1);
@@ -4394,7 +4397,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -4402,7 +4405,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
   *xd1 = 3.7;
   b1Derivative = 3.7;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -4415,17 +4418,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_2) {
 
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_2) {
   double a = 4., b = 3.2, bout;
-  short const tapeId = 1;
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
   b = std::fmax(a, b);
@@ -4435,7 +4439,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == bDerivative, tt::tolerance(tol));
 
@@ -4447,13 +4451,13 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_2) {
 
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd1 <<= b1;
 
   bd1 = fmax(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.5;
   b1 = std::fmax(a1, b1);
@@ -4463,7 +4467,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_2) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == b1Derivative, tt::tolerance(tol));
 
@@ -4474,18 +4478,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::fmax(a, b);
 
@@ -4496,7 +4500,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_3) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -4507,18 +4511,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_ZOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 1.0, as the active variable is grater than the passive
    * one. */
@@ -4533,7 +4537,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -4548,13 +4552,13 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
 
   adouble ad1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad1 <<= a1;
 
   ad1 = fmax(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.;
   a1 = std::fmax(a1, b1);
@@ -4567,7 +4571,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -4575,7 +4579,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
   *xd1 = 3.7;
   a1Derivative = 3.7;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -4589,18 +4593,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = std::fmax(a, b);
@@ -4610,7 +4614,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_3) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -4622,13 +4626,13 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_3) {
 
   adouble ad1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
 
   ad1 = fmax(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.5;
   a1 = std::fmax(a1, b1);
@@ -4638,7 +4642,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_3) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == a1Derivative, tt::tolerance(tol));
 
@@ -4649,20 +4653,20 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOS_Reverse_3) {
 BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::max(a, b);
 
@@ -4674,7 +4678,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_1) {
   *x = 4.;
   *(x + 1) = 3.2;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -4685,20 +4689,20 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -4715,7 +4719,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_1) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -4724,7 +4728,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_1) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -4744,7 +4748,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_1) {
   *xd1 = 1.3;
   *(xd1 + 1) = 3.7;
 
-  fos_forward(tapeId, 1, 2, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 2, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == 2.5, tt::tolerance(tol));
   BOOST_TEST(*yd1 == 3.7, tt::tolerance(tol));
@@ -4758,20 +4762,20 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -4781,7 +4785,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -4795,21 +4799,21 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_1) {
   adouble ad1;
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
   bd1 <<= b1;
 
   ad1 = max(ad1, bd1);
 
   ad1 >>= out1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *u1 = myalloc1(1);
   double *z1 = myalloc1(2);
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 2, u1, z1);
+  fos_reverse(*tapePtr, 1, 2, u1, z1);
 
   BOOST_TEST(*z1 == 0.5, tt::tolerance(tol));
   BOOST_TEST(*(z1 + 1) == 0.5, tt::tolerance(tol));
@@ -4821,18 +4825,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   b = std::max(a, b);
 
@@ -4843,7 +4847,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_2) {
 
   *x = 3.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
 
@@ -4854,18 +4858,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 0.0, as the active variable is smaller than the passive
    * one. */
@@ -4880,7 +4884,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
   *x = 3.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
@@ -4895,13 +4899,13 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
 
   adouble bd1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd1 <<= b1;
 
   bd1 = max(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.;
   b1 = std::max(a1, b1);
@@ -4914,7 +4918,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -4922,7 +4926,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
   *xd1 = 3.7;
   b1Derivative = 3.7;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -4935,17 +4939,17 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_2) {
 
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_2) {
   double a = 4., b = 3.2, bout;
-  short const tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
   b = std::max(a, b);
@@ -4955,7 +4959,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == bDerivative, tt::tolerance(tol));
 
@@ -4967,13 +4971,13 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_2) {
 
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd1 <<= b1;
 
   bd1 = max(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.5;
   b1 = std::max(a1, b1);
@@ -4983,7 +4987,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_2) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == b1Derivative, tt::tolerance(tol));
 
@@ -4994,18 +4998,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::max(a, b);
 
@@ -5016,7 +5020,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_3) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -5027,18 +5031,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_ZOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 1.0, as the active variable is grater than the passive
    * one. */
@@ -5053,7 +5057,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -5068,13 +5072,13 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
 
   adouble ad1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad1 <<= a1;
 
   ad1 = max(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.;
   a1 = std::max(a1, b1);
@@ -5087,7 +5091,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -5095,7 +5099,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
   *xd1 = 3.7;
   a1Derivative = 3.7;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -5109,18 +5113,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = std::max(a, b);
@@ -5130,7 +5134,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_3) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -5142,13 +5146,13 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_3) {
 
   adouble ad1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
 
   ad1 = max(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.5;
   a1 = std::max(a1, b1);
@@ -5158,7 +5162,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_3) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == a1Derivative, tt::tolerance(tol));
 
@@ -5169,20 +5173,20 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOS_Reverse_3) {
 BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::fmin(a, b);
 
@@ -5194,7 +5198,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_1) {
   *x = 4.;
   *(x + 1) = 3.2;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -5205,20 +5209,20 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -5235,7 +5239,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_1) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -5244,7 +5248,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_1) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -5264,7 +5268,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_1) {
   *xd1 = 1.3;
   *(xd1 + 1) = 3.7;
 
-  fos_forward(tapeId, 1, 2, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 2, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == 2.5, tt::tolerance(tol));
   BOOST_TEST(*yd1 == 1.3, tt::tolerance(tol));
@@ -5278,20 +5282,20 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -5301,7 +5305,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -5315,21 +5319,21 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_1) {
   adouble ad1;
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
   bd1 <<= b1;
 
   ad1 = fmin(ad1, bd1);
 
   ad1 >>= out1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *u1 = myalloc1(1);
   double *z1 = myalloc1(2);
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 2, u1, z1);
+  fos_reverse(*tapePtr, 1, 2, u1, z1);
 
   BOOST_TEST(*z1 == 0.5, tt::tolerance(tol));
   BOOST_TEST(*(z1 + 1) == 0.5, tt::tolerance(tol));
@@ -5341,18 +5345,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   b = std::fmin(a, b);
 
@@ -5363,7 +5367,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_2) {
 
   *x = 3.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
 
@@ -5374,18 +5378,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 1.0, as the active variable is smaller than the passive
    * one. */
@@ -5400,7 +5404,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
   *x = 3.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
@@ -5415,13 +5419,13 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
 
   adouble bd1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd1 <<= b1;
 
   bd1 = fmin(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = -1.3;
   b1 = std::fmin(a1, b1);
@@ -5434,7 +5438,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -5442,7 +5446,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
   *xd1 = 3.7;
   b1Derivative = 0.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -5456,18 +5460,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
   b = std::fmin(a, b);
@@ -5477,7 +5481,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == bDerivative, tt::tolerance(tol));
 
@@ -5489,13 +5493,13 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_2) {
 
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd1 <<= b1;
 
   bd1 = fmin(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.5;
   b1 = std::fmin(a1, b1);
@@ -5505,7 +5509,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_2) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == b1Derivative, tt::tolerance(tol));
 
@@ -5516,18 +5520,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::fmin(a, b);
 
@@ -5538,7 +5542,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_3) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -5549,18 +5553,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_ZOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 0.0, as the active variable is grater than the passive
    * one. */
@@ -5575,7 +5579,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -5590,13 +5594,13 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
 
   adouble ad1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad1 <<= a1;
 
   ad1 = fmin(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = -1.3;
   a1 = std::fmin(a1, b1);
@@ -5609,7 +5613,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -5617,7 +5621,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
   *xd1 = 3.7;
   a1Derivative = 0.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -5631,18 +5635,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::fmin(a, b);
@@ -5652,7 +5656,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_3) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -5664,13 +5668,13 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_3) {
 
   adouble ad1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
 
   ad1 = fmin(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.5;
   a1 = std::fmin(a1, b1);
@@ -5680,7 +5684,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_3) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == a1Derivative, tt::tolerance(tol));
 
@@ -5691,20 +5695,20 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOS_Reverse_3) {
 BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::min(a, b);
 
@@ -5716,7 +5720,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_1) {
   *x = 4.;
   *(x + 1) = 3.2;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -5727,20 +5731,20 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -5757,7 +5761,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_1) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -5766,7 +5770,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_1) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -5786,7 +5790,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_1) {
   *xd1 = 1.3;
   *(xd1 + 1) = 3.7;
 
-  fos_forward(tapeId, 1, 2, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 2, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == 2.5, tt::tolerance(tol));
   BOOST_TEST(*yd1 == 1.3, tt::tolerance(tol));
@@ -5800,20 +5804,20 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -5823,7 +5827,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -5837,21 +5841,21 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_1) {
   adouble ad1;
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
   bd1 <<= b1;
 
   ad1 = min(ad1, bd1);
 
   ad1 >>= out1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *u1 = myalloc1(1);
   double *z1 = myalloc1(2);
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 2, u1, z1);
+  fos_reverse(*tapePtr, 1, 2, u1, z1);
 
   BOOST_TEST(*z1 == 0.5, tt::tolerance(tol));
   BOOST_TEST(*(z1 + 1) == 0.5, tt::tolerance(tol));
@@ -5863,18 +5867,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   b = std::min(a, b);
 
@@ -5885,7 +5889,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_2) {
 
   *x = 3.2;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
 
@@ -5896,18 +5900,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 1.0, as the active variable is smaller than the passive
    * one. */
@@ -5922,7 +5926,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
   *x = 3.2;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
@@ -5937,13 +5941,13 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
 
   adouble bd1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd1 <<= b1;
 
   bd1 = min(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = -1.3;
   b1 = std::min(a1, b1);
@@ -5956,7 +5960,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -5964,7 +5968,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
   *xd1 = 3.7;
   b1Derivative = 0.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == b1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == b1Derivative, tt::tolerance(tol));
@@ -5978,18 +5982,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
   b = std::min(a, b);
@@ -5999,7 +6003,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == bDerivative, tt::tolerance(tol));
 
@@ -6011,13 +6015,13 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_2) {
 
   adouble bd1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd1 <<= b1;
 
   bd1 = min(a1, bd1);
 
   bd1 >>= bout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double b1Derivative = 0.5;
   b1 = std::min(a1, b1);
@@ -6027,7 +6031,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_2) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == b1Derivative, tt::tolerance(tol));
 
@@ -6038,18 +6042,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::min(a, b);
 
@@ -6060,7 +6064,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_3) {
 
   *x = 4.;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6071,18 +6075,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_ZOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   /* Derivative value is 0.0, as the active variable is grater than the passive
    * one. */
@@ -6097,7 +6101,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
   *x = 4.;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6112,13 +6116,13 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
 
   adouble ad1;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad1 <<= a1;
 
   ad1 = min(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = -1.3;
   a1 = std::min(a1, b1);
@@ -6131,7 +6135,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
   *x1 = 2.5;
   *xd1 = -1.3;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -6139,7 +6143,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
   *xd1 = 3.7;
   a1Derivative = 0.;
 
-  fos_forward(tapeId, 1, 1, 0, x1, xd1, y1, yd1);
+  fos_forward(*tapePtr, 1, 1, 0, x1, xd1, y1, yd1);
 
   BOOST_TEST(*y1 == a1, tt::tolerance(tol));
   BOOST_TEST(*yd1 == a1Derivative, tt::tolerance(tol));
@@ -6153,18 +6157,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Forward_3) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::min(a, b);
@@ -6174,7 +6178,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_3) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6186,13 +6190,13 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_3) {
 
   adouble ad1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad1 <<= a1;
 
   ad1 = min(ad1, b1);
 
   ad1 >>= aout1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double a1Derivative = 0.5;
   a1 = std::min(a1, b1);
@@ -6202,7 +6206,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_3) {
 
   *u1 = 1.;
 
-  fos_reverse(tapeId, 1, 1, u1, z1);
+  fos_reverse(*tapePtr, 1, 1, u1, z1);
 
   BOOST_TEST(*z1 == a1Derivative, tt::tolerance(tol));
 
@@ -6213,18 +6217,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOS_Reverse_3) {
 BOOST_AUTO_TEST_CASE(ErfOperator_ZOS_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erf(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::erf(a);
 
@@ -6235,7 +6239,7 @@ BOOST_AUTO_TEST_CASE(ErfOperator_ZOS_Forward) {
 
   *x = 7.1;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6246,18 +6250,18 @@ BOOST_AUTO_TEST_CASE(ErfOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erf(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
   a = std::erf(a);
@@ -6270,7 +6274,7 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Forward) {
   *x = 7.1;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6284,18 +6288,18 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Reverse) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = erf(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
 
@@ -6304,7 +6308,7 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6315,18 +6319,18 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(ErfcOperator_ZOS_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erfc(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::erfc(a);
 
@@ -6337,7 +6341,7 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_ZOS_Forward) {
 
   *x = 7.1;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6348,18 +6352,18 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erfc(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
   a = std::erfc(a);
@@ -6372,7 +6376,7 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Forward) {
   *x = 7.1;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6386,18 +6390,18 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Reverse) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = erfc(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
 
@@ -6406,7 +6410,7 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6417,19 +6421,19 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(EqOperator_ZOS_Forward) {
   double a = 10.01, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   bd = ad;
 
   bd >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   BOOST_TEST(aout == a, tt::tolerance(tol));
 
@@ -6438,7 +6442,7 @@ BOOST_AUTO_TEST_CASE(EqOperator_ZOS_Forward) {
 
   *x = 10.01;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6449,19 +6453,19 @@ BOOST_AUTO_TEST_CASE(EqOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqOperator_FOS_Forward) {
   double a = 10.01, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   bd = ad;
 
   bd >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -6473,7 +6477,7 @@ BOOST_AUTO_TEST_CASE(EqOperator_FOS_Forward) {
   *x = 10.01;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6487,19 +6491,19 @@ BOOST_AUTO_TEST_CASE(EqOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqOperator_FOS_Reverse) {
   double a = 10.01, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   bd = ad;
 
   bd >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -6508,7 +6512,7 @@ BOOST_AUTO_TEST_CASE(EqOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6519,18 +6523,18 @@ BOOST_AUTO_TEST_CASE(EqOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_ZOS_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad += 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a += 5.2;
 
@@ -6541,7 +6545,7 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_ZOS_Forward) {
 
   *x = 5.132;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6552,18 +6556,18 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad += 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a += 5.2;
   double aDerivative = 1.;
@@ -6576,7 +6580,7 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Forward) {
   *x = 5.132;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6590,18 +6594,18 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad += 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a += 5.2;
   double aDerivative = 1.;
@@ -6611,7 +6615,7 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6623,48 +6627,48 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_FOS_Forward_2) {
   double a = 1.0, b = -1.0, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad += bd * 2;
   ad >>= out;
 
-  trace_off();
+  trace_off(*tapePtr);
 
   std::vector<double> xd{0.0, 1.0};
   std::vector<double> in{a, b};
   std::vector<double> grad(1);
-  fos_forward(tapeId, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
+  fos_forward(*tapePtr, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
   BOOST_TEST(grad[0] == 2, tt::tolerance(tol));
 
   xd[0] = 1.0;
   xd[1] = 0.0;
-  fos_forward(tapeId, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
+  fos_forward(*tapePtr, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
   BOOST_TEST(grad[0] == 1, tt::tolerance(tol));
 }
 
 BOOST_AUTO_TEST_CASE(EqMinusOperator_ZOS_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad -= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a -= 5.2;
 
@@ -6675,7 +6679,7 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_ZOS_Forward) {
 
   *x = 5.132;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6686,18 +6690,18 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad -= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a -= 5.2;
   double aDerivative = 1.;
@@ -6710,7 +6714,7 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Forward) {
   *x = 5.132;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6725,48 +6729,48 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Forward) {
 BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Forward_2) {
   double a = 1.0, b = -1.0, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad -= bd * 2;
   ad >>= out;
 
-  trace_off();
+  trace_off(*tapePtr);
 
   std::vector<double> xd{0.0, 1.0};
   std::vector<double> in{a, b};
   std::vector<double> grad(1);
-  fos_forward(tapeId, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
+  fos_forward(*tapePtr, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
   BOOST_TEST(grad[0] == -2, tt::tolerance(tol));
 
   xd[0] = 1.0;
   xd[1] = 0.0;
-  fos_forward(tapeId, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
+  fos_forward(*tapePtr, 1, 2, 0, in.data(), xd.data(), &out, grad.data());
   BOOST_TEST(grad[0] == 1, tt::tolerance(tol));
 }
 
 BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad -= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a -= 5.2;
   double aDerivative = 1.;
@@ -6776,7 +6780,7 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Reverse) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6787,18 +6791,18 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOS_Reverse) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad *= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a *= 5.2;
 
@@ -6809,7 +6813,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_1) {
 
   *x = 5.132;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6820,18 +6824,18 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad *= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a *= 5.2;
   double aDerivative = 5.2;
@@ -6844,7 +6848,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_1) {
   *x = 5.132;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6858,18 +6862,18 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad *= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a *= 5.2;
   double aDerivative = 5.2;
@@ -6879,7 +6883,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -6890,20 +6894,20 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad *= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a *= b;
 
@@ -6915,7 +6919,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_2) {
   *x = 5.132;
   *(x + 1) = 11.1;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -6926,20 +6930,20 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad *= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -6956,7 +6960,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_2) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -6965,7 +6969,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_2) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -6978,20 +6982,20 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad *= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -7001,7 +7005,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -7013,18 +7017,18 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad /= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a /= 5.2;
 
@@ -7035,7 +7039,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_1) {
 
   *x = 5.132;
 
-  zos_forward(tapeId, 1, 1, 0, x, y);
+  zos_forward(*tapePtr, 1, 1, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -7046,18 +7050,18 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad /= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a /= 5.2;
   double aDerivative = 1. / 5.2;
@@ -7070,7 +7074,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_1) {
   *x = 5.132;
   *xd = 1.;
 
-  fos_forward(tapeId, 1, 1, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -7084,18 +7088,18 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_1) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_1) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad /= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a /= 5.2;
   double aDerivative = 1. / 5.2;
@@ -7105,7 +7109,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_1) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 1, u, z);
+  fos_reverse(*tapePtr, 1, 1, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
 
@@ -7116,20 +7120,20 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_1) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad /= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   a /= b;
 
@@ -7141,7 +7145,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_2) {
   *x = 5.132;
   *(x + 1) = 11.1;
 
-  zos_forward(tapeId, 1, 2, 0, x, y);
+  zos_forward(*tapePtr, 1, 2, 0, x, y);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
 
@@ -7152,20 +7156,20 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_ZOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad /= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -7182,7 +7186,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_2) {
   *xd = 1.;
   *(xd + 1) = 0.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(*yd == aDerivative, tt::tolerance(tol));
@@ -7191,7 +7195,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_2) {
   *xd = 0.;
   *(xd + 1) = 1.;
 
-  fos_forward(tapeId, 1, 2, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 0, x, xd, y, yd);
 
   BOOST_TEST(*yd == bDerivative, tt::tolerance(tol));
 
@@ -7204,20 +7208,20 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Forward_2) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_2) {
   double a = 5.132, b = 11.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad /= bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -7227,7 +7231,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_2) {
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 2, u, z);
+  fos_reverse(*tapePtr, 1, 2, u, z);
 
   BOOST_TEST(*z == aDerivative, tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == bDerivative, tt::tolerance(tol));
@@ -7239,15 +7243,15 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOS_Reverse_2) {
 BOOST_AUTO_TEST_CASE(CondassignOperator_ZOS_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7255,7 +7259,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_ZOS_Forward) {
   condassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   BOOST_TEST(out == 3.5, tt::tolerance(tol));
 
@@ -7266,7 +7270,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_ZOS_Forward) {
   *(x + 1) = 3.5;
   *(x + 2) = 5.3;
 
-  zos_forward(tapeId, 1, 3, 0, x, y);
+  zos_forward(*tapePtr, 1, 3, 0, x, y);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
 
@@ -7277,15 +7281,15 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7293,7 +7297,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Forward) {
   condassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   BOOST_TEST(out == 3.5, tt::tolerance(tol));
 
@@ -7309,7 +7313,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Forward) {
   *(xd + 1) = 0.1;
   *(xd + 2) = 0.2;
 
-  fos_forward(tapeId, 1, 3, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
   BOOST_TEST(*yd == 0.1, tt::tolerance(tol));
@@ -7326,7 +7330,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Reverse)
   adouble cond, arg1, arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7334,7 +7338,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Reverse)
   condassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -7344,7 +7348,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Reverse)
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 3, u, z);
+  fos_reverse(*tapePtr, 1, 3, u, z);
 
   BOOST_TEST(*z == 0., tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == aDerivative, tt::tolerance(tol));
@@ -7357,15 +7361,15 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOS_Reverse)
 BOOST_AUTO_TEST_CASE(CondeqassignOperator_ZOS_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7373,7 +7377,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_ZOS_Forward) {
   condeqassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   BOOST_TEST(out == 3.5, tt::tolerance(tol));
 
@@ -7384,7 +7388,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_ZOS_Forward) {
   *(x + 1) = 3.5;
   *(x + 2) = 5.3;
 
-  zos_forward(tapeId, 1, 3, 0, x, y);
+  zos_forward(*tapePtr, 1, 3, 0, x, y);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
 
@@ -7395,15 +7399,15 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_ZOS_Forward) {
 BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7411,7 +7415,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Forward) {
   condeqassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   BOOST_TEST(out == 3.5, tt::tolerance(tol));
 
@@ -7427,7 +7431,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Forward) {
   *(xd + 1) = 0.1;
   *(xd + 2) = 0.2;
 
-  fos_forward(tapeId, 1, 3, 0, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 0, x, xd, y, yd);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
   BOOST_TEST(*yd == 0.1, tt::tolerance(tol));
@@ -7444,7 +7448,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Reverse)
   adouble cond, arg1, arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -7452,7 +7456,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Reverse)
   condeqassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -7462,7 +7466,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Reverse)
 
   *u = 1.;
 
-  fos_reverse(tapeId, 1, 3, u, z);
+  fos_reverse(*tapePtr, 1, 3, u, z);
 
   BOOST_TEST(*z == 0., tt::tolerance(tol));
   BOOST_TEST(*(z + 1) == aDerivative, tt::tolerance(tol));
@@ -7480,8 +7484,8 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOS_Reverse)
 BOOST_AUTO_TEST_CASE(TraceNotOperatorPrimal) {
   double a = 1.0;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
 
@@ -7491,8 +7495,8 @@ BOOST_AUTO_TEST_CASE(TraceNotOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompNeqOperatorPrimal) {
   double a = 1.5, b = 0.5;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7511,8 +7515,8 @@ BOOST_AUTO_TEST_CASE(TraceCompNeqOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompEqOperatorPrimal) {
   double a = 0.5, b = 1.5;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7531,8 +7535,8 @@ BOOST_AUTO_TEST_CASE(TraceCompEqOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompLeqOperatorPrimal) {
   double a = 1.0, b = 0.99;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7551,8 +7555,8 @@ BOOST_AUTO_TEST_CASE(TraceCompLeqOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompGeqOperatorPrimal) {
   double a = 1.2, b = 2.5;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7571,8 +7575,8 @@ BOOST_AUTO_TEST_CASE(TraceCompGeqOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompLeOperatorPrimal) {
   double a = 1.1, b = 1.1;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7591,8 +7595,8 @@ BOOST_AUTO_TEST_CASE(TraceCompLeOperatorPrimal) {
 BOOST_AUTO_TEST_CASE(TraceCompGeOperatorPrimal) {
   double a = 1.7, b = 7.5;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad(a);
   adouble bd(b);
@@ -7610,8 +7614,8 @@ BOOST_AUTO_TEST_CASE(TraceCompGeOperatorPrimal) {
 
 BOOST_AUTO_TEST_CASE(IsnormalOperatorPrimal) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ad(1.7);
 
   BOOST_TEST(isnormal(ad), tt::tolerance(tol));
@@ -7621,8 +7625,8 @@ BOOST_AUTO_TEST_CASE(IsnormalOperatorPrimal) {
 
 BOOST_AUTO_TEST_CASE(IsnanOperatorPrimal) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ad(1.7);
 
   BOOST_TEST(!isnan(ad), tt::tolerance(tol));
@@ -7632,8 +7636,8 @@ BOOST_AUTO_TEST_CASE(IsnanOperatorPrimal) {
 
 BOOST_AUTO_TEST_CASE(IsinfOperatorPrimal) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ad(1.7);
 
   BOOST_TEST(!isinf(ad), tt::tolerance(tol));
@@ -7643,8 +7647,8 @@ BOOST_AUTO_TEST_CASE(IsinfOperatorPrimal) {
 
 BOOST_AUTO_TEST_CASE(IsfiniteOperatorPrimal) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ad(1.7);
 
   BOOST_TEST(isfinite(ad), tt::tolerance(tol));

--- a/ADOL-C/boost-test/traceOperatorVector.cpp
+++ b/ADOL-C/boost-test/traceOperatorVector.cpp
@@ -25,18 +25,18 @@ BOOST_AUTO_TEST_SUITE(trace_vector)
 BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Forward) {
   double a = 2., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = exp(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::exp(a);
   double aDerivative = a;
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Forward) {
     xd[0][i] = 1. + i;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -67,18 +67,18 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Reverse) {
   double a = 2., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = exp(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::exp(a);
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::exp(3.);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::exp(3.), tt::tolerance(tol));
@@ -100,20 +100,20 @@ BOOST_AUTO_TEST_CASE(ExpOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(MultOperator_FOV_Forward) {
   double a = 2., b = 3.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad * bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -152,20 +152,20 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(MultOperator_FOV_Reverse) {
   double a = 2., b = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad * bd;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b;
   double bDerivative = a;
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -190,20 +190,20 @@ BOOST_AUTO_TEST_CASE(MultOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AddOperator_FOV_Forward) {
   double a = 2.5, b = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad + bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -242,20 +242,20 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(AddOperator_FOV_Reverse) {
   double a = 2.5, b = 3., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad + bd;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 9.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -280,20 +280,20 @@ BOOST_AUTO_TEST_CASE(AddOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SubOperator_FOV_Forward) {
   double a = 1.5, b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad - bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -332,20 +332,20 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SubOperator_FOV_Reverse) {
   double a = 1.5, b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad - bd;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = -1.;
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(2);
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -370,20 +370,20 @@ BOOST_AUTO_TEST_CASE(SubOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(DivOperator_FOV_Forward) {
   double a = 0.5, b = 4.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad / bd;
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -422,20 +422,20 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(DivOperator_FOV_Reverse) {
   double a = 0.5, b = 4.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad / bd;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / b;
   double bDerivative = -a / (b * b);
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 0.9;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -460,18 +460,18 @@ BOOST_AUTO_TEST_CASE(DivOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(TanOperator_FOV_Forward) {
   double a = 0.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = tan(a);
   double aDerivative = 1. + a * a;
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOV_Forward) {
     xd[0][i] = 1. + std::pow(2, i);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative * (1. + std::pow(2, 0)),
@@ -504,18 +504,18 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(TanOperator_FOV_Reverse) {
   double a = 0.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = tan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tan(a);
   double aDerivative = 1. + a * a;
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 1.1, tt::tolerance(tol));
@@ -538,18 +538,18 @@ BOOST_AUTO_TEST_CASE(TanOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SinOperator_FOV_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cos(a);
   a = sin(a);
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOV_Forward) {
     xd[0][i] = 1. + i * (-2.0);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -580,18 +580,18 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SinOperator_FOV_Reverse) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cos(a);
 
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::tan(4.4);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::tan(4.4), tt::tolerance(tol));
@@ -613,18 +613,18 @@ BOOST_AUTO_TEST_CASE(SinOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CosOperator_FOV_Forward) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -std::sin(a);
   a = cos(a);
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 2.;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -655,18 +655,18 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CosOperator_FOV_Reverse) {
   double a = 1.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -std::sin(a);
 
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::log(2.);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::log(2.), tt::tolerance(tol));
@@ -688,18 +688,18 @@ BOOST_AUTO_TEST_CASE(CosOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sqrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::sqrt(a);
   double aDerivative = 1. / (2. * a);
@@ -715,7 +715,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Forward) {
     xd[0][i] = 1. * std::pow(2, i);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -730,18 +730,18 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Reverse) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sqrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (2. * std::sqrt(a));
 
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::exp(2.);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::exp(2.), tt::tolerance(tol));
@@ -763,19 +763,19 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Forward) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
   // cbrt(a)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cbrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   // cbrt(a)
   const double out = std::cbrt(a);
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Forward) {
     xd[0][i] = 1. * std::pow(2, i);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == out, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -809,19 +809,19 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Reverse) {
   double a = 2.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
   // cbrt(a)
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cbrt(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   // 1 / 3 * a^(-2 / 3)
   const double aDerivative = 1. / (3.0 * std::pow(a, 2.0 / 3.0));
@@ -832,7 +832,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::exp(2.);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::exp(2.), tt::tolerance(tol));
@@ -844,18 +844,18 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(LogOperator_FOV_Forward) {
   double a = 4.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / a;
   a = std::log(a);
@@ -871,7 +871,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 5.5;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -886,18 +886,18 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(LogOperator_FOV_Reverse) {
   double a = 4.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = log(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / a;
 
@@ -907,7 +907,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::exp(-1.);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::exp(-1.), tt::tolerance(tol));
@@ -919,18 +919,18 @@ BOOST_AUTO_TEST_CASE(LogOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = sinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cosh(a);
   a = std::sinh(a);
@@ -946,7 +946,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Forward) {
     xd[0][i] = 1. - std::sqrt(2. * i);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -962,18 +962,18 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = sinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::cosh(a);
 
@@ -983,7 +983,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::cosh(3.5);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::cosh(3.5), tt::tolerance(tol));
@@ -995,18 +995,18 @@ BOOST_AUTO_TEST_CASE(SinhOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = cosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::sinh(a);
   a = std::cosh(a);
@@ -1022,7 +1022,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 3.2;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1037,18 +1037,18 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = cosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::sinh(a);
 
@@ -1058,7 +1058,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sinh(3.5);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::sinh(3.5), tt::tolerance(tol));
@@ -1070,18 +1070,18 @@ BOOST_AUTO_TEST_CASE(CoshOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Forward) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = tanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tanh(a);
   double aDerivative = 1. - a * a;
@@ -1097,7 +1097,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Forward) {
     xd[0][i] = 1. - 1.3 * i;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1112,18 +1112,18 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Reverse) {
   double a = 4., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = tanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   a = std::tanh(a);
   double aDerivative = 1. - a * a;
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 5.4;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 5.4 * aDerivative, tt::tolerance(tol));
@@ -1146,18 +1146,18 @@ BOOST_AUTO_TEST_CASE(TanhOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Forward) {
   double a = 0.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(1. - a * a));
   a = std::asin(a);
@@ -1173,7 +1173,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Forward) {
     xd[0][i] = 1. + i * (i + 1.7) * 4.3;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1188,18 +1188,18 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Reverse) {
   double a = 0.9, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = asin(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(1. - a * a));
 
@@ -1209,7 +1209,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. + 2.7 * 4.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. + 2.7 * 4.3), tt::tolerance(tol));
@@ -1221,18 +1221,18 @@ BOOST_AUTO_TEST_CASE(AsinOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Forward) {
   double a = 0.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1. / (std::sqrt(1. - a * a));
   a = std::acos(a);
@@ -1248,7 +1248,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Forward) {
     xd[0][i] = 1. - i * (i + 0.7) * 3.4;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1263,18 +1263,18 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Reverse) {
   double a = 0.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = acos(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1. / (std::sqrt(1. - a * a));
 
@@ -1284,7 +1284,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. - 1.7 * 3.4;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. - 1.7 * 3.4), tt::tolerance(tol));
@@ -1296,18 +1296,18 @@ BOOST_AUTO_TEST_CASE(AcosOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AtanOperator_FOV_Forward) {
   double a = 9.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. + a * a);
   a = std::atan(a);
@@ -1323,7 +1323,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOV_Forward) {
     xd[0][i] = 1. - i * (i - 0.3) * 4.3;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1338,18 +1338,18 @@ BOOST_AUTO_TEST_CASE(AtanOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Atanperator_FOV_Reverse) {
   double a = 9.8, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = atan(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. + a * a);
 
@@ -1359,7 +1359,7 @@ BOOST_AUTO_TEST_CASE(Atanperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. - 0.7 * 4.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. - 0.7 * 4.3), tt::tolerance(tol));
@@ -1371,18 +1371,18 @@ BOOST_AUTO_TEST_CASE(Atanperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(Log10Operator_FOV_Forward) {
   double a = 12.3, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = log10(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (a * std::log(10));
   a = std::log10(a);
@@ -1398,7 +1398,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOV_Forward) {
     xd[0][i] = 1. + i * 9.9;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1413,18 +1413,18 @@ BOOST_AUTO_TEST_CASE(Log10Operator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Log10perator_FOV_Reverse) {
   double a = 12.3, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = log10(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (a * std::log(10));
 
@@ -1434,7 +1434,7 @@ BOOST_AUTO_TEST_CASE(Log10perator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. + 9.9;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. + 9.9), tt::tolerance(tol));
@@ -1446,18 +1446,18 @@ BOOST_AUTO_TEST_CASE(Log10perator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AsinhOperator_FOV_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = asinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a + 1.));
   a = std::asinh(a);
@@ -1473,7 +1473,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 6.2;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1488,18 +1488,18 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Asinhperator_FOV_Reverse) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = asinh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a + 1.));
 
@@ -1509,7 +1509,7 @@ BOOST_AUTO_TEST_CASE(Asinhperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. - 6.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. - 6.1), tt::tolerance(tol));
@@ -1521,18 +1521,18 @@ BOOST_AUTO_TEST_CASE(Asinhperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AcoshOperator_FOV_Forward) {
   double a = 1.7, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = acosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a - 1.));
   a = std::acosh(a);
@@ -1548,7 +1548,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 3.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1563,18 +1563,18 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Acoshperator_FOV_Reverse) {
   double a = 1.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = acosh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (std::sqrt(a * a - 1.));
 
@@ -1584,7 +1584,7 @@ BOOST_AUTO_TEST_CASE(Acoshperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. + 3.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. + 3.1), tt::tolerance(tol));
@@ -1596,18 +1596,18 @@ BOOST_AUTO_TEST_CASE(Acoshperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AtanhOperator_FOV_Forward) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = atanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. - a * a);
   a = std::atanh(a);
@@ -1623,7 +1623,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 2.2;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1638,18 +1638,18 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Atanhperator_FOV_Reverse) {
   double a = 0.6, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = atanh(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / (1. - a * a);
 
@@ -1659,7 +1659,7 @@ BOOST_AUTO_TEST_CASE(Atanhperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 1. + 2.2;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * (1. + 2.2), tt::tolerance(tol));
@@ -1671,18 +1671,18 @@ BOOST_AUTO_TEST_CASE(Atanhperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(InclOperator_FOV_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ++ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   ++a;
@@ -1698,7 +1698,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 4.2;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1713,18 +1713,18 @@ BOOST_AUTO_TEST_CASE(InclOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Inclperator_FOV_Reverse) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ++ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -1734,7 +1734,7 @@ BOOST_AUTO_TEST_CASE(Inclperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(5);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::sqrt(5), tt::tolerance(tol));
@@ -1746,18 +1746,18 @@ BOOST_AUTO_TEST_CASE(Inclperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(DeclOperator_FOV_Forward) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   --ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   --a;
@@ -1773,7 +1773,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 4.2;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1788,18 +1788,18 @@ BOOST_AUTO_TEST_CASE(DeclOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Declperator_FOV_Reverse) {
   double a = 5., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   --ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -1809,7 +1809,7 @@ BOOST_AUTO_TEST_CASE(Declperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(5);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::sqrt(5), tt::tolerance(tol));
@@ -1821,18 +1821,18 @@ BOOST_AUTO_TEST_CASE(Declperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = +ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = +a;
@@ -1848,7 +1848,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 0.8;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1863,18 +1863,18 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Reverse) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = +ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -1884,7 +1884,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(3);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::sqrt(3), tt::tolerance(tol));
@@ -1896,18 +1896,18 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Forward) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = -ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
   a = -a;
@@ -1923,7 +1923,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 0.8;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -1938,18 +1938,18 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Reverse) {
   double a = 1.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = -ad;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -1.;
 
@@ -1959,7 +1959,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::sqrt(3);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::sqrt(3), tt::tolerance(tol));
@@ -1971,20 +1971,20 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Forward) {
   double a = 12.3, b = 2.1, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = atan2(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b / (a * a + b * b);
   double bDerivative = -a / (a * a + b * b);
@@ -2008,7 +2008,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Forward) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2023,20 +2023,20 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Reverse) {
   double a = 12.3, b = 2.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = atan2(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b / (a * a + b * b);
   double bDerivative = -a / (a * a + b * b);
@@ -2047,7 +2047,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::exp(1.);
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -2061,18 +2061,18 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_1) {
   double a = 2.3, e = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = pow(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = e * std::pow(a, e - 1.);
   a = std::pow(a, e);
@@ -2088,7 +2088,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_1) {
     xd[0][i] = 1. + i * 0.5;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2103,18 +2103,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_1) {
   double a = 2.3, e = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = pow(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = e * std::pow(a, e - 1.);
 
@@ -2124,7 +2124,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = -1.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == -1.1 * aDerivative, tt::tolerance(tol));
@@ -2135,20 +2135,20 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_1) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_2) {
   double a = 2.3, b = 3.5, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = pow(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b * std::pow(a, b - 1.);
   double bDerivative = std::log(a) * std::pow(a, b);
@@ -2172,7 +2172,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_2) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2187,20 +2187,20 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_2) {
   double a = 2.3, b = 3.5, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = pow(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = b * std::pow(a, b - 1.);
   double bDerivative = std::pow(a, b) * std::log(a);
@@ -2211,7 +2211,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -2225,18 +2225,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_3) {
   double a = 2.3, e = 3.5, eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ed;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ed <<= e;
 
   ed = pow(a, ed);
 
   ed >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double eDerivative = std::log(a) * std::pow(a, e);
   a = std::pow(a, e);
@@ -2252,7 +2252,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_3) {
     xd[0][i] = 1. + i * 0.5;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == eDerivative, tt::tolerance(tol));
@@ -2267,18 +2267,18 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_3) {
   double a = 2.3, e = 3.4, eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ed;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ed <<= e;
 
   ed = pow(a, ed);
 
   ed >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double eDerivative = std::pow(a, e) * std::log(a);
 
@@ -2288,7 +2288,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = -1.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == eDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == -1.1 * eDerivative, tt::tolerance(tol));
@@ -2302,20 +2302,20 @@ BOOST_AUTO_TEST_CASE(PowOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_1) {
   double a = 4., b = 3., out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = ad * pow(2., bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., b);
   double bDerivative = a * std::log(2.) * std::pow(2., b);
@@ -2339,7 +2339,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_1) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2354,20 +2354,20 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_1) {
   double a = 4., b = 3., aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = ad * pow(2., bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., b);
   double bDerivative = a * std::pow(2., b) * std::log(2.);
@@ -2378,7 +2378,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = -2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -2393,18 +2393,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_2) {
   double a = 4., aout;
   int e = 3;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ldexp(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., e);
   a = std::ldexp(a, e);
@@ -2420,7 +2420,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_2) {
     xd[0][i] = 1. + i;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2435,18 +2435,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_2) {
   double a = 4., aout;
   int e = 3;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = ldexp(ad, e);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = std::pow(2., e);
 
@@ -2456,7 +2456,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = std::exp(std::log(10.));
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == std::exp(std::log(10.)) * aDerivative,
@@ -2469,18 +2469,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_3) {
   double a = 4., eout;
   int e = 3;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ed;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ed <<= e;
 
   ed = a * pow(2., ed);
 
   ed >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double eDerivative = a * std::log(2.) * std::pow(2., e);
   auto res = std::ldexp(a, e);
@@ -2496,7 +2496,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_3) {
     xd[0][i] = 1. + i;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == res, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == eDerivative, tt::tolerance(tol));
@@ -2511,18 +2511,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_3) {
   double a = 4., e = 3., eout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ed;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ed <<= e;
 
   ed = a * pow(2., ed);
 
   ed >>= eout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double eDerivative = a * std::pow(2., e) * std::log(2.);
 
@@ -2532,7 +2532,7 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = 2.2;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == eDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 2.2 * eDerivative, tt::tolerance(tol));
@@ -2544,18 +2544,18 @@ BOOST_AUTO_TEST_CASE(LdexpOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Forward) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = std::fabs(a);
@@ -2571,7 +2571,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 1.5;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2582,7 +2582,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Forward) {
   a = std::fabs(-5.);
   aDerivative = -1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2593,7 +2593,7 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Forward) {
   xd[0][0] = 2.5;
   xd[0][1] = -3.5;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == 0., tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == 2.5, tt::tolerance(tol));
@@ -2608,18 +2608,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Reverse) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -2629,44 +2629,44 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 3.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 3.3 * aDerivative, tt::tolerance(tol));
   a = -5.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = -1.;
 
   u[0][0] = 1.;
   u[1][0] = 3.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 3.3 * aDerivative, tt::tolerance(tol));
 
   a = 0.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fabs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 2.5;
   u[1][0] = -3.5;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0., tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 0., tt::tolerance(tol));
@@ -2678,18 +2678,18 @@ BOOST_AUTO_TEST_CASE(FabsOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Forward) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a = std::abs(a);
@@ -2705,7 +2705,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 1.5;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2716,7 +2716,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Forward) {
   a = std::abs(-5.);
   aDerivative = -1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2727,7 +2727,7 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Forward) {
   xd[0][0] = 2.5;
   xd[0][1] = -3.5;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == 0., tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == 2.5, tt::tolerance(tol));
@@ -2742,18 +2742,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Reverse) {
   double a = 1.4, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -2763,44 +2763,44 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 3.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 3.3 * aDerivative, tt::tolerance(tol));
   a = -5.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = -1.;
 
   u[0][0] = 1.;
   u[1][0] = 3.3;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 3.3 * aDerivative, tt::tolerance(tol));
 
   a = 0.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = abs(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 2.5;
   u[1][0] = -3.5;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0., tt::tolerance(tol));
   BOOST_TEST(z[1][0] == 0., tt::tolerance(tol));
@@ -2812,18 +2812,18 @@ BOOST_AUTO_TEST_CASE(AbsOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Forward) {
   double a = 3.573, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::ceil(a);
@@ -2839,7 +2839,7 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Forward) {
     xd[0][i] = 1. + i * 5.8;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2854,18 +2854,18 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Reverse) {
   double a = 3.573, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = ceil(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -2875,7 +2875,7 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -2887,18 +2887,18 @@ BOOST_AUTO_TEST_CASE(CeilOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Forward) {
   double a = 4.483, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = floor(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   a = std::floor(a);
@@ -2914,7 +2914,7 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Forward) {
     xd[0][i] = 1. - i * 5.8;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -2929,18 +2929,18 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Reverse) {
   double a = 4.483, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = floor(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -2950,7 +2950,7 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -2962,20 +2962,20 @@ BOOST_AUTO_TEST_CASE(FloorOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -2999,7 +2999,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_1) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3017,7 +3017,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_1) {
   aDerivative = std::fmax(xd[0][0], xd[1][0]);
   bDerivative = std::fmax(xd[0][1], xd[1][1]);
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3032,20 +3032,20 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_1) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -3056,7 +3056,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -3065,19 +3065,19 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_1) {
 
   a = 2.5, b = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmax(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 1.;
   u[1][0] = -1.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0.5, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == 0.5, tt::tolerance(tol));
@@ -3091,18 +3091,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_1) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
   b = std::fmax(a, b);
@@ -3118,7 +3118,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_2) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3133,7 +3133,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_2) {
   b = std::fmax(a, x[0]);
   bDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3148,7 +3148,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_2) {
   b = std::fmax(a, x[0]);
   bDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3163,18 +3163,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
 
@@ -3184,47 +3184,47 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 5.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 1.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 4.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmax(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
@@ -3236,18 +3236,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -3264,7 +3264,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_3) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3279,7 +3279,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_3) {
   a = std::fmax(x[0], b);
   aDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3295,7 +3295,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_3) {
   aDerivative = std::fmax(xd[0][0], 0.0);
   bDerivative = std::fmax(xd[0][1], 0.0);
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3310,18 +3310,18 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -3331,47 +3331,47 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 3.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmax(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -3383,20 +3383,20 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -3420,7 +3420,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_1) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3438,7 +3438,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_1) {
   aDerivative = std::max(xd[0][0], xd[1][0]);
   bDerivative = std::max(xd[0][1], xd[1][1]);
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3453,20 +3453,20 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_1) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 0.;
@@ -3477,7 +3477,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -3486,19 +3486,19 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_1) {
 
   a = 2.5, b = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = max(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 1.;
   u[1][0] = -1.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0.5, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == 0.5, tt::tolerance(tol));
@@ -3512,18 +3512,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_1) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
   b = std::max(a, b);
@@ -3539,7 +3539,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_2) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3554,7 +3554,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_2) {
   b = std::max(a, x[0]);
   bDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3569,7 +3569,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_2) {
   b = std::max(a, x[0]);
   bDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3584,18 +3584,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 0.;
 
@@ -3605,47 +3605,47 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 5.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 1.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 4.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = max(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
@@ -3657,18 +3657,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   double bDerivative = 1.;
@@ -3685,7 +3685,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_3) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3700,7 +3700,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_3) {
   a = std::max(x[0], b);
   aDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3716,7 +3716,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_3) {
   aDerivative = std::max(xd[0][0], 0.0);
   bDerivative = std::max(xd[0][1], 0.0);
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3731,18 +3731,18 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -3752,47 +3752,47 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 3.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = max(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -3804,20 +3804,20 @@ BOOST_AUTO_TEST_CASE(MaxOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -3841,7 +3841,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_1) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3859,7 +3859,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_1) {
   aDerivative = std::fmin(xd[0][0], xd[1][0]);
   bDerivative = std::fmin(xd[0][1], xd[1][1]);
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -3874,20 +3874,20 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_1) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -3898,7 +3898,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -3907,19 +3907,19 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_1) {
 
   a = 2.5, b = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = fmin(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 1.;
   u[1][0] = -1.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0.5, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == 0.5, tt::tolerance(tol));
@@ -3933,18 +3933,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_1) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
   b = std::fmin(a, b);
@@ -3960,7 +3960,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_2) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3975,7 +3975,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_2) {
   b = std::fmin(a, x[0]);
   bDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -3990,7 +3990,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_2) {
   b = std::fmin(a, x[0]);
   bDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -4005,18 +4005,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
 
@@ -4026,47 +4026,47 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 5.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 4.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = fmin(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
@@ -4078,18 +4078,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 0.;
@@ -4106,7 +4106,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_3) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4121,7 +4121,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_3) {
   a = std::fmin(x[0], b);
   aDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4137,7 +4137,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_3) {
   aDerivative = std::fmin(xd[0][0], 0.0);
   bDerivative = std::fmin(xd[0][1], 0.0);
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4152,18 +4152,18 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -4173,47 +4173,47 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 1.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 3.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = fmin(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -4225,20 +4225,20 @@ BOOST_AUTO_TEST_CASE(FminOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_1) {
   double a = 4., b = 3.2, out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -4262,7 +4262,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_1) {
     }
   }
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4280,7 +4280,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_1) {
   aDerivative = std::min(xd[0][0], xd[1][0]);
   bDerivative = std::min(xd[0][1], xd[1][1]);
 
-  fov_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4295,20 +4295,20 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_1) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_1) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 1.;
@@ -4319,7 +4319,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_1) {
   u[0][0] = 1.;
   u[1][0] = 2.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == bDerivative, tt::tolerance(tol));
@@ -4328,19 +4328,19 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_1) {
 
   a = 2.5, b = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
   bd <<= b;
 
   ad = min(ad, bd);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   u[0][0] = 1.;
   u[1][0] = -1.;
 
-  fov_reverse(tapeId, 1, 2, 2, u, z);
+  fov_reverse(*tapePtr, 1, 2, 2, u, z);
 
   BOOST_TEST(z[0][0] == 0.5, tt::tolerance(tol));
   BOOST_TEST(z[0][1] == 0.5, tt::tolerance(tol));
@@ -4354,18 +4354,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_1) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
   b = std::min(a, b);
@@ -4381,7 +4381,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_2) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -4396,7 +4396,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_2) {
   b = std::min(a, x[0]);
   bDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -4411,7 +4411,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_2) {
   b = std::min(a, x[0]);
   bDerivative = 0.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == b, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == bDerivative, tt::tolerance(tol));
@@ -4426,18 +4426,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_2) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_2) {
   double a = 4., b = 3.2, bout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble bd;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double bDerivative = 1.;
 
@@ -4447,47 +4447,47 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_2) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 5.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
 
   b = 4.;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   bd <<= b;
 
   bd = min(a, bd);
 
   bd >>= bout;
-  trace_off();
+  trace_off(*tapePtr);
 
   bDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == bDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == bDerivative * 6.8, tt::tolerance(tol));
@@ -4499,18 +4499,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_2) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
   double bDerivative = 0.;
@@ -4527,7 +4527,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_3) {
     xd[0][i] = 1. - i * 2.1;
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4542,7 +4542,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_3) {
   a = std::min(x[0], b);
   aDerivative = 1.;
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4558,7 +4558,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_3) {
   aDerivative = std::min(xd[0][0], 0.0);
   bDerivative = std::min(xd[0][1], 0.0);
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4573,18 +4573,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Forward_3) {
 BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_3) {
   double a = 4., b = 3.2, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 0.;
 
@@ -4594,47 +4594,47 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_3) {
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 2.5;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 1.;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
 
   a = 3.2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = min(ad, b);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   aDerivative = 0.5;
 
   u[0][0] = 1.;
   u[1][0] = 6.8;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * 6.8, tt::tolerance(tol));
@@ -4646,18 +4646,18 @@ BOOST_AUTO_TEST_CASE(MinOperator_FOV_Reverse_3) {
 BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erf(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
   a = std::erf(a);
@@ -4673,7 +4673,7 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Forward) {
     xd[0][i] = std::pow(3., i * 2.);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4688,18 +4688,18 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Reverse) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = erf(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
 
@@ -4709,7 +4709,7 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = -1.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == -1.1 * aDerivative, tt::tolerance(tol));
@@ -4721,18 +4721,18 @@ BOOST_AUTO_TEST_CASE(ErfOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Forward) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad = erfc(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
   a = std::erfc(a);
@@ -4748,7 +4748,7 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Forward) {
     xd[0][i] = std::pow(3., i * 2.);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4763,18 +4763,18 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Reverse) {
   double a = 7.1, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad = erfc(ad);
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = -2. / std::sqrt(std::acos(-1.)) * std::exp(-a * a);
 
@@ -4784,7 +4784,7 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = -1.1;
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == -1.1 * aDerivative, tt::tolerance(tol));
@@ -4796,18 +4796,18 @@ BOOST_AUTO_TEST_CASE(ErfcOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad += 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a += 5.2;
@@ -4823,7 +4823,7 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Forward) {
     xd[0][i] = std::pow(4., i * 1.5);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4838,18 +4838,18 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad += 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -4859,7 +4859,7 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::pow(2., -1.1);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::pow(2., -1.1), tt::tolerance(tol));
@@ -4871,18 +4871,18 @@ BOOST_AUTO_TEST_CASE(EqPlusOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad -= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
   a -= 5.2;
@@ -4898,7 +4898,7 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Forward) {
     xd[0][i] = std::pow(4., i * 1.5);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4913,18 +4913,18 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad -= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1.;
 
@@ -4934,7 +4934,7 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::pow(2., -1.1);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::pow(2., -1.1), tt::tolerance(tol));
@@ -4946,18 +4946,18 @@ BOOST_AUTO_TEST_CASE(EqMinusOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad *= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 5.2;
   a *= 5.2;
@@ -4973,7 +4973,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Forward) {
     xd[0][i] = std::pow(4., i * 1.5);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -4988,18 +4988,18 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad *= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 5.2;
 
@@ -5009,7 +5009,7 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::pow(2., -1.1);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::pow(2., -1.1), tt::tolerance(tol));
@@ -5021,18 +5021,18 @@ BOOST_AUTO_TEST_CASE(EqTimesOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Forward) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   ad <<= a;
 
   ad /= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / 5.2;
   a /= 5.2;
@@ -5048,7 +5048,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Forward) {
     xd[0][i] = std::pow(4., i * 1.5);
   }
 
-  fov_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == a, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == aDerivative, tt::tolerance(tol));
@@ -5063,18 +5063,18 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Reverse) {
   double a = 5.132, aout;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble ad;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ad <<= a;
 
   ad /= 5.2;
 
   ad >>= aout;
-  trace_off();
+  trace_off(*tapePtr);
 
   double aDerivative = 1. / 5.2;
 
@@ -5084,7 +5084,7 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Reverse) {
   u[0][0] = 1.;
   u[1][0] = std::pow(2., -1.1);
 
-  fov_reverse(tapeId, 1, 1, 2, u, z);
+  fov_reverse(*tapePtr, 1, 1, 2, u, z);
 
   BOOST_TEST(z[0][0] == aDerivative, tt::tolerance(tol));
   BOOST_TEST(z[1][0] == aDerivative * std::pow(2., -1.1), tt::tolerance(tol));
@@ -5096,15 +5096,15 @@ BOOST_AUTO_TEST_CASE(EqDivOperator_FOV_Reverse) {
 BOOST_AUTO_TEST_CASE(CondassignOperator_FOV_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -5112,7 +5112,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOV_Forward) {
   condassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *x = myalloc1(3);
   double **xd = myalloc2(3, 2);
@@ -5133,7 +5133,7 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOV_Forward) {
     xd[0][i] = 1. + i;
   }
 
-  fov_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == 0.1, tt::tolerance(tol));
@@ -5148,15 +5148,15 @@ BOOST_AUTO_TEST_CASE(CondassignOperator_FOV_Forward) {
 BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOV_Forward) {
   double out;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   adouble cond;
   adouble arg1;
   adouble arg2;
   adouble p;
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   cond <<= 1.;
   arg1 <<= 3.5;
   arg2 <<= 5.3;
@@ -5164,7 +5164,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOV_Forward) {
   condeqassign(p, cond, arg1, arg2);
 
   p >>= out;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *x = myalloc1(3);
   double **xd = myalloc2(3, 2);
@@ -5185,7 +5185,7 @@ BOOST_AUTO_TEST_CASE(CondeqassignOperator_FOV_Forward) {
     xd[0][i] = 1. + i;
   }
 
-  fov_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fov_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   BOOST_TEST(*y == 3.5, tt::tolerance(tol));
   BOOST_TEST(yd[0][0] == 0.1, tt::tolerance(tol));

--- a/ADOL-C/boost-test/traceSecOrderScalar.cpp
+++ b/ADOL-C/boost-test/traceSecOrderScalar.cpp
@@ -33,21 +33,21 @@ BOOST_AUTO_TEST_SUITE(trace_sec_order)
  */
 BOOST_AUTO_TEST_CASE(CustomCube_HOS) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
 
   double x = 3.;
   adouble ax;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax <<= x;
 
   ay = 2. * ax * ax * ax;
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   // Calculate primitive value analytically for testing.
   double yprim = 2. * x * x * x;
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(CustomCube_HOS) {
   Y = myalloc2(1, 2);
 
   // Signature: hos_forward(tag, m, n, d, keep, x[n], X[n][d], y[m], Y[m][d])
-  hos_forward(tapeId, 1, 1, 2, 1, &x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 1, 2, 1, &x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(CustomCube_HOS) {
   // Calculate Hessian matrix analytically:
   double yxxDerivative = 2. * 3. * 2. * x;
 
-  hessian(tapeId, 1, &x, H);
+  hessian(*tapePtr, 1, &x, H);
 
   BOOST_TEST(yxxDerivative == H[0][0], tt::tolerance(tol));
 
@@ -96,21 +96,21 @@ BOOST_AUTO_TEST_CASE(CustomCube_HOS) {
 BOOST_AUTO_TEST_CASE(CustomTrigProd_HOS) {
   double x1 = 1.3, x2 = 3.1;
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = cos(ax1) * sin(ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::cos(x1) * std::sin(x2);
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigProd_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigProd_HOS) {
   double yx1x2Derivative = -std::sin(x1) * std::cos(x2);
   double yx2x2Derivative = -std::cos(x1) * std::sin(x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -179,15 +179,15 @@ BOOST_AUTO_TEST_CASE(CustomTrigProd_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomTrigPow_HOS) {
   double x1 = 1.1, x2 = 4.53, x3 = -3.03;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigPow_HOS) {
   ay = pow(ax1, ax2) * exp(2. * ax3);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::pow(x1, x2) * std::exp(2. * x3);
 
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigPow_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 3, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 3, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigPow_HOS) {
       2. * std::pow(x1, x2) * std::log(x1) * std::exp(2. * x3);
   double yx3x3Derivative = 4. * std::pow(x1, x2) * std::exp(2. * x3);
 
-  hessian(tapeId, 3, x, H);
+  hessian(*tapePtr, 3, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -277,21 +277,21 @@ BOOST_AUTO_TEST_CASE(CustomTrigPow_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomHyperbProd_HOS) {
   double x1 = 2.22, x2 = -2.22;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = cosh(2. * ax1) * sinh(3. * ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::cosh(2. * x1) * std::sinh(3. * x2);
 
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(CustomHyperbProd_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(CustomHyperbProd_HOS) {
   double yx1x2Derivative = 6. * std::sinh(2. * x1) * std::cosh(3. * x2);
   double yx2x2Derivative = 9. * std::cosh(2. * x1) * std::sinh(3. * x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -360,21 +360,21 @@ BOOST_AUTO_TEST_CASE(CustomHyperbProd_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomPowTrig_HOS) {
   double x1 = 0.531, x2 = 3.12;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = pow(sin(ax1), cos(ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::pow(std::sin(x1), std::cos(x2));
 
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(CustomPowTrig_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(CustomPowTrig_HOS) {
       std::pow(std::sin(x1), std::cos(x2)) * std::log(std::sin(x1)) *
       (-std::cos(x2) + std::pow(std::sin(x2), 2) * std::log(std::sin(x1)));
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -448,21 +448,21 @@ BOOST_AUTO_TEST_CASE(CustomPowTrig_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomPow_HOS) {
   double x1 = 1.04, x2 = -2.01;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = pow(ax1, ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::pow(x1, x2);
 
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(CustomPow_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(CustomPow_HOS) {
   double yx1x2Derivative = std::pow(x1, x2 - 1) * (1 + x2 * std::log(x1));
   double yx2x2Derivative = std::pow(x1, x2) * std::pow(std::log(x1), 2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -539,8 +539,8 @@ BOOST_AUTO_TEST_CASE(CustomPow_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
   double x1 = -1.1, x2 = -4.53, x3 = 3.03, x4 = 0.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -557,7 +557,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
   ay = exp(ax1 + 3. * ax2 + 5. * ax3 + 7. * ax4);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::exp(x1 + 3. * x2 + 5. * x3 + 7. * x4);
 
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 4, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 4, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
   double yx4x3Derivative = 35. * std::exp(x1 + 3. * x2 + 5. * x3 + 7. * x4);
   double yx4x4Derivative = 49. * std::exp(x1 + 3. * x2 + 5. * x3 + 7. * x4);
 
-  hessian(tapeId, 4, x, H);
+  hessian(*tapePtr, 4, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -650,21 +650,21 @@ BOOST_AUTO_TEST_CASE(CustomExpSum_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomHypErf_HOS) {
   double x1 = 5.55, x2 = 9.99;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = exp(tanh(ax1) * erf(ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::exp(std::tanh(x1) * std::erf(x2));
 
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE(CustomHypErf_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE(CustomHypErf_HOS) {
       (4 * std::tanh(x1) / std::acos(-1) -
        4 * x2 * std::exp(x2 * x2) / std::sqrt(std::acos(-1)));
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -739,21 +739,21 @@ BOOST_AUTO_TEST_CASE(CustomHypErf_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomHypAtan_HOS) {
   double x1 = 7.19, x2 = -4.32;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = (pow(cosh(ax1), 2) - pow(sinh(ax1), 2)) * atan(ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim =
       (std::pow(std::cosh(x1), 2) - std::pow(std::sinh(x1), 2)) * std::atan(x2);
@@ -778,7 +778,7 @@ BOOST_AUTO_TEST_CASE(CustomHypAtan_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -791,7 +791,7 @@ BOOST_AUTO_TEST_CASE(CustomHypAtan_HOS) {
   double yx1x2Derivative = 0.;
   double yx2x2Derivative = -2. * x2 / std::pow(1. + x2 * x2, 2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -814,15 +814,15 @@ BOOST_AUTO_TEST_CASE(CustomHypAtan_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomLongSum_HOS) {
   double x1 = 99.99, x2 = std::exp(-0.44), x3 = std::sqrt(2);
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -831,7 +831,7 @@ BOOST_AUTO_TEST_CASE(CustomLongSum_HOS) {
        ax3 * ax3 * ax3 * ax3;
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = 1. + x1 + x1 * x1 + x2 * x2 + x2 * x2 * x2 + x3 * x3 * x3 +
                  x3 * x3 * x3 * x3;
@@ -860,7 +860,7 @@ BOOST_AUTO_TEST_CASE(CustomLongSum_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 3, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 3, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -876,7 +876,7 @@ BOOST_AUTO_TEST_CASE(CustomLongSum_HOS) {
   double yx3x2Derivative = 0.;
   double yx3x3Derivative = 6. * x3 + 12. * x3 * x3;
 
-  hessian(tapeId, 3, x, H);
+  hessian(*tapePtr, 3, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -910,15 +910,15 @@ BOOST_AUTO_TEST_CASE(CustomLongSum_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomExpSqrt_HOS) {
   double x1 = -0.77, x2 = 10.01, x3 = 0.99;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -926,7 +926,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSqrt_HOS) {
   ay = exp(ax1) * sqrt(2. * ax2) * pow(ax3, 2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::exp(x1) * std::sqrt(2. * x2) * std::pow(x3, 2);
 
@@ -954,7 +954,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSqrt_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 3, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 3, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -971,7 +971,7 @@ BOOST_AUTO_TEST_CASE(CustomExpSqrt_HOS) {
   double yx3x2Derivative = std::exp(x1) * 2. * x3 / std::sqrt(2. * x2);
   double yx3x3Derivative = 2. * std::exp(x1) * std::sqrt(2. * x2);
 
-  hessian(tapeId, 3, x, H);
+  hessian(*tapePtr, 3, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -996,21 +996,21 @@ BOOST_AUTO_TEST_CASE(CustomExpSqrt_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomInvHyperb_HOS) {
   double x1 = -3.03, x2 = 0.11;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = 2. * acosh(cosh(ax1 * ax1)) * atanh(ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = 2. * std::acosh(std::cosh(x1 * x1)) * std::atanh(x2);
 
@@ -1034,7 +1034,7 @@ BOOST_AUTO_TEST_CASE(CustomInvHyperb_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1047,7 +1047,7 @@ BOOST_AUTO_TEST_CASE(CustomInvHyperb_HOS) {
   double yx1x2Derivative = 4. * x1 / (1. - x2 * x2);
   double yx2x2Derivative = 4. * x1 * x1 * x2 / std::pow(1. - x2 * x2, 2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1069,8 +1069,8 @@ BOOST_AUTO_TEST_CASE(CustomInvHyperb_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
   double x1 = 1., x2 = 2.5, x3 = -4.5, x4 = -1.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1087,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
   ay = fmax(fmin(ax1, ax2), fabs(ax3)) * ax4;
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::fmax(std::fmin(x1, x2), std::fabs(x3)) * x4;
 
@@ -1117,7 +1117,7 @@ BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 4, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 4, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1137,7 +1137,7 @@ BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
   double yx4x3Derivative = -1.;
   double yx4x4Derivative = 0.;
 
-  hessian(tapeId, 4, x, H);
+  hessian(*tapePtr, 4, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -1166,8 +1166,8 @@ BOOST_AUTO_TEST_CASE(CustomFminFmaxFabs_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
   double x1 = 1., x2 = 2.5, x3 = -4.5, x4 = -1.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -1175,7 +1175,7 @@ BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
   ay = max(min(ax1, ax2), abs(ax3)) * ax4;
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::max(std::min(x1, x2), std::abs(x3)) * x4;
 
@@ -1214,7 +1214,7 @@ BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 4, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 4, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1234,7 +1234,7 @@ BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
   double yx4x3Derivative = -1.;
   double yx4x4Derivative = 0.;
 
-  hessian(tapeId, 4, x, H);
+  hessian(*tapePtr, 4, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -1271,8 +1271,8 @@ BOOST_AUTO_TEST_CASE(CustomMinMaxAbs_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
   double x1 = 0.11, x2 = 0.33, x3 = 0.1 * std::acos(0.), x4 = std::exp(-1.);
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -1280,7 +1280,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1289,7 +1289,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
   ay = 3. * asin(sin(ax1 + ax2)) * sin(ax3) * cos(ax4);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim =
       3. * std::asin(std::sin(x1 + x2)) * std::sin(x3) * std::cos(x4);
@@ -1327,7 +1327,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 4, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 4, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1347,7 +1347,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
   double yx4x3Derivative = -3. * (x1 + x2) * std::cos(x3) * std::sin(x4);
   double yx4x4Derivative = -3. * (x1 + x2) * std::sin(x3) * std::cos(x4);
 
-  hessian(tapeId, 4, x, H);
+  hessian(*tapePtr, 4, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -1378,21 +1378,21 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomInvTrig2_HOS) {
   double x1 = 0.53, x2 = -0.01;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = atan(ax1) * asin(ax2);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::atan(x1) * std::asin(x2);
 
@@ -1417,7 +1417,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig2_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1431,7 +1431,7 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig2_HOS) {
   double yx2x2Derivative =
       std::atan(x1) * x2 / std::pow(std::sqrt(1. - x2 * x2), 3);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1452,21 +1452,21 @@ BOOST_AUTO_TEST_CASE(CustomInvTrig2_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomFabsFmax_HOS) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = fmax(fabs(ax1 * ax1), fabs(ax2 * ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::fmax(std::fabs(x1 * x1), std::fabs(x2 * x2));
 
@@ -1490,7 +1490,7 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmax_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1503,7 +1503,7 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmax_HOS) {
   double yx1x2Derivative = 0.;
   double yx2x2Derivative = 0.;
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1524,21 +1524,21 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmax_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomAbsMax_HOS) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = max(abs(ax1 * ax1), abs(ax2 * ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::max(std::abs(x1 * x1), std::abs(x2 * x2));
 
@@ -1562,7 +1562,7 @@ BOOST_AUTO_TEST_CASE(CustomAbsMax_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1575,7 +1575,7 @@ BOOST_AUTO_TEST_CASE(CustomAbsMax_HOS) {
   double yx1x2Derivative = 0.;
   double yx2x2Derivative = 0.;
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1596,21 +1596,21 @@ BOOST_AUTO_TEST_CASE(CustomAbsMax_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomFabsFmin_HOS) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = fmin(fabs(ax1 * ax1), fabs(ax2 * ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::fmin(std::fabs(x1 * x1), std::fabs(x2 * x2));
 
@@ -1634,7 +1634,7 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmin_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1647,7 +1647,7 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmin_HOS) {
   double yx1x2Derivative = 0.;
   double yx2x2Derivative = 2.;
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1669,21 +1669,21 @@ BOOST_AUTO_TEST_CASE(CustomFabsFmin_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomFmaxTrigExp_HOS) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = fmax(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2) * exp(ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::fmax(x1 * x1 * std::cos(x2),
                            std::sin(x1) * std::cos(x2) * std::exp(x2));
@@ -1708,7 +1708,7 @@ BOOST_AUTO_TEST_CASE(CustomFmaxTrigExp_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1721,7 +1721,7 @@ BOOST_AUTO_TEST_CASE(CustomFmaxTrigExp_HOS) {
   double yx1x2Derivative = -2. * x1 * std::sin(x2);
   double yx2x2Derivative = -x1 * x1 * std::cos(x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1736,21 +1736,21 @@ BOOST_AUTO_TEST_CASE(CustomFmaxTrigExp_HOS) {
 
 BOOST_AUTO_TEST_CASE(CustomMaxTrigExp_HOS) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = max(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2) * exp(ax2));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::max(x1 * x1 * std::cos(x2),
                           std::sin(x1) * std::cos(x2) * std::exp(x2));
@@ -1775,7 +1775,7 @@ BOOST_AUTO_TEST_CASE(CustomMaxTrigExp_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1788,7 +1788,7 @@ BOOST_AUTO_TEST_CASE(CustomMaxTrigExp_HOS) {
   double yx1x2Derivative = -2. * x1 * std::sin(x2);
   double yx2x2Derivative = -x1 * x1 * std::cos(x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1814,21 +1814,21 @@ BOOST_AUTO_TEST_CASE(CustomMaxTrigExp_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomFminTrigExp_HOS) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = fmin(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2 * exp(ax2)));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::fmin(x1 * x1 * std::cos(x2),
                            std::sin(x1) * std::cos(x2 * std::exp(x2)));
@@ -1854,7 +1854,7 @@ BOOST_AUTO_TEST_CASE(CustomFminTrigExp_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1871,7 +1871,7 @@ BOOST_AUTO_TEST_CASE(CustomFminTrigExp_HOS) {
           std::pow((1. + x2) * std::exp(x2), 2) -
       std::sin(x1) * std::sin(x2 * std::exp(x2)) * (2. + x2) * std::exp(x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1886,21 +1886,21 @@ BOOST_AUTO_TEST_CASE(CustomFminTrigExp_HOS) {
 
 BOOST_AUTO_TEST_CASE(CustomMinTrigExp_HOS) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay = min(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2 * exp(ax2)));
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::min(x1 * x1 * std::cos(x2),
                           std::sin(x1) * std::cos(x2 * std::exp(x2)));
@@ -1926,7 +1926,7 @@ BOOST_AUTO_TEST_CASE(CustomMinTrigExp_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 2, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 2, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -1943,7 +1943,7 @@ BOOST_AUTO_TEST_CASE(CustomMinTrigExp_HOS) {
           std::pow((1. + x2) * std::exp(x2), 2) -
       std::sin(x1) * std::sin(x2 * std::exp(x2)) * (2. + x2) * std::exp(x2);
 
-  hessian(tapeId, 2, x, H);
+  hessian(*tapePtr, 2, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx1x2Derivative == H[1][0], tt::tolerance(tol));
@@ -1981,15 +1981,15 @@ BOOST_AUTO_TEST_CASE(CustomMinTrigExp_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomPowExpTan_HOS) {
   double x1 = -5.2, x2 = 1.1, x3 = 5.4;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -1997,7 +1997,7 @@ BOOST_AUTO_TEST_CASE(CustomPowExpTan_HOS) {
   ay = pow(ax1, 3) * pow(ax2, 4) * exp(tan(ax3)) + ax3 + sqrt(11);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = std::pow(x1, 3) * std::pow(x2, 4) * std::exp(std::tan(x3)) +
                  x3 + sqrt(11);
@@ -2030,7 +2030,7 @@ BOOST_AUTO_TEST_CASE(CustomPowExpTan_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 3, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 3, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -2055,7 +2055,7 @@ BOOST_AUTO_TEST_CASE(CustomPowExpTan_HOS) {
                            (1. + std::pow(std::tan(x3), 2)) *
                            (1. + 2. * std::tan(x3) + std::pow(std::tan(x3), 2));
 
-  hessian(tapeId, 3, x, H);
+  hessian(*tapePtr, 3, x, H);
 
   BOOST_TEST(yx1x1Derivative == H[0][0], tt::tolerance(tol));
   BOOST_TEST(yx2x1Derivative == H[1][0], tt::tolerance(tol));
@@ -2084,8 +2084,8 @@ BOOST_AUTO_TEST_CASE(CustomPowExpTan_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
   double x1 = 1.5, x2 = -1.5, x3 = 3., x4 = -3., x5 = 4.5, x6 = -4.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -2095,7 +2095,7 @@ BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2107,7 +2107,7 @@ BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
        (ax1 * ax1 + ax2 * ax2 + ax3 * ax3 + ax4 * ax4 + ax5 * ax5 + ax6 * ax6);
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim =
       0.5 * (x1 * x1 + x2 * x2 + x3 * x3 + x4 * x4 + x5 * x5 + x6 * x6);
@@ -2144,7 +2144,7 @@ BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 6, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 6, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -2153,7 +2153,7 @@ BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
   double **H;
   H = myalloc2(6, 6);
 
-  hessian(tapeId, 6, x, H);
+  hessian(*tapePtr, 6, x, H);
 
   BOOST_TEST(H[0][0] == 1., tt::tolerance(tol));
   BOOST_TEST(H[1][0] == 0., tt::tolerance(tol));
@@ -2197,8 +2197,8 @@ BOOST_AUTO_TEST_CASE(CustomManyVariabl_HOS) {
  */
 BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
   double x1 = 1., x2 = -1., x3 = 3.5, x4 = -3.5, x5 = 4., x6 = -4.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -2208,7 +2208,7 @@ BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
   double y;
   adouble ay;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2219,7 +2219,7 @@ BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
   ay = 0.001001;
 
   ay >>= y;
-  trace_off();
+  trace_off(*tapePtr);
 
   double yprim = 0.001001;
 
@@ -2255,7 +2255,7 @@ BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
   double **Y;
   Y = myalloc2(1, 2);
 
-  hos_forward(tapeId, 1, 6, 2, 1, x, X, &y, Y);
+  hos_forward(*tapePtr, 1, 6, 2, 1, x, X, &y, Y);
 
   BOOST_TEST(y == yprim, tt::tolerance(tol));
   BOOST_TEST(Y[0][0] == yDerivative[0][0], tt::tolerance(tol));
@@ -2264,7 +2264,7 @@ BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
   double **H;
   H = myalloc2(6, 6);
 
-  hessian(tapeId, 6, x, H);
+  hessian(*tapePtr, 6, x, H);
 
   BOOST_TEST(H[0][0] == 0., tt::tolerance(tol));
   BOOST_TEST(H[1][0] == 0., tt::tolerance(tol));
@@ -2309,8 +2309,8 @@ BOOST_AUTO_TEST_CASE(CustomConstant_HOS) {
 
 BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   double x1 = 1., x2 = -1., x3 = 0.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -2318,7 +2318,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   adouble ay1;
   adouble ay2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2328,7 +2328,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
 
   ay1 >>= y1;
   ay2 >>= y2;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::exp(x2 + x3);
   double y1x2Derivative = x1 * std::exp(x2 + x3);
@@ -2368,7 +2368,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(2);
   double **Z = myalloc2(3, 2);
@@ -2376,7 +2376,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2393,7 +2393,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2407,12 +2407,12 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2425,7 +2425,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2439,12 +2439,12 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2457,7 +2457,7 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2477,8 +2477,8 @@ BOOST_AUTO_TEST_CASE(customSimpleSum_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   double x1 = 1.78, x2 = -7.81, x3 = 0.03;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -2486,7 +2486,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   adouble ay1;
   adouble ay2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2496,7 +2496,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
 
   ay1 >>= y1;
   ay2 >>= y2;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative =
       std::exp(std::sin(x2) * std::cos(x3) + std::sqrt(2) + 3. * x3);
@@ -2562,7 +2562,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(2);
   double **Z = myalloc2(3, 2);
@@ -2570,7 +2570,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2583,7 +2583,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2597,12 +2597,12 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2615,7 +2615,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2629,12 +2629,12 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2647,7 +2647,7 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2667,8 +2667,8 @@ BOOST_AUTO_TEST_CASE(customTrigExp_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   double x1 = 2.35, x2 = 5.6, x3 = 2.66;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -2676,7 +2676,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   adouble ay1;
   adouble ay2;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2686,7 +2686,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
 
   ay1 >>= y1;
   ay2 >>= y2;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = x2 * std::pow(x1, x2 - 1.);
   double y1x2Derivative = std::pow(x1, x2) * std::log(x1);
@@ -2740,7 +2740,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(2);
   double **Z = myalloc2(3, 2);
@@ -2748,7 +2748,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2761,7 +2761,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2775,12 +2775,12 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2793,7 +2793,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2807,12 +2807,12 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 2, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 2, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2825,7 +2825,7 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
   u[0] = 0.;
   u[1] = 1.;
 
-  hos_reverse(tapeId, 2, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 2, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -2845,19 +2845,19 @@ BOOST_AUTO_TEST_CASE(customPowPow_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customCube_HOS_Reverse) {
   double x1 = 3.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
 
   ay1 = 2. * ax1 * ax1 * ax1;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 6. * x1 * x1;
 
@@ -2871,14 +2871,14 @@ BOOST_AUTO_TEST_CASE(customCube_HOS_Reverse) {
   x[0] = 3.;
   xd[0] = 1.;
 
-  fos_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(1, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 1, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 1, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[0][1] == y1x1x1Derivative, tt::tolerance(tol));
@@ -2893,21 +2893,21 @@ BOOST_AUTO_TEST_CASE(customCube_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customTrigProd_HOS_Reverse) {
   double x1 = 1.3, x2 = 3.1;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = cos(ax1) * sin(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = -std::sin(x1) * std::sin(x2);
   double y1x2Derivative = std::cos(x1) * std::cos(x2);
@@ -2927,14 +2927,14 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2945,9 +2945,9 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -2965,15 +2965,15 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
   double x1 = 1.1, x2 = 4.53, x3 = -3.03;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -2981,7 +2981,7 @@ BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
   ay1 = pow(ax1, ax2) * exp(2. * ax3);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = x2 * pow(x1, x2 - 1) * exp(2. * x3);
   double y1x2Derivative = pow(x1, x2) * log(x1) * exp(2. * x3);
@@ -3017,14 +3017,14 @@ BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(3, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3038,9 +3038,9 @@ BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3054,9 +3054,9 @@ BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3076,21 +3076,21 @@ BOOST_AUTO_TEST_CASE(customTrigPow_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customHyperbProd_HOS_Reverse) {
   double x1 = 2.22, x2 = -2.22;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = cosh(2. * ax1) * sinh(3. * ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 2. * std::sinh(2. * x1) * std::sinh(3. * x2);
   double y1x2Derivative = std::cosh(2. * x1) * 3. * std::cosh(3. * x2);
@@ -3110,14 +3110,14 @@ BOOST_AUTO_TEST_CASE(customHyperbProd_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3128,9 +3128,9 @@ BOOST_AUTO_TEST_CASE(customHyperbProd_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3148,21 +3148,21 @@ BOOST_AUTO_TEST_CASE(customHyperbProd_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customPowTrig_HOS_Reverse) {
   double x1 = 0.531, x2 = 3.12;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = pow(sin(ax1), cos(ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::pow(std::sin(x1), std::cos(x2)) * std::cos(x2) *
                           std::cos(x1) / std::sin(x1);
@@ -3194,14 +3194,14 @@ BOOST_AUTO_TEST_CASE(customPowTrig_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3212,9 +3212,9 @@ BOOST_AUTO_TEST_CASE(customPowTrig_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3232,21 +3232,21 @@ BOOST_AUTO_TEST_CASE(customPowTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customPow_HOS_Reverse) {
   double x1 = 1.04, x2 = -2.01;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = pow(ax1, ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = x2 * std::pow(x1, x2 - 1);
   double y1x2Derivative = std::pow(x1, x2) * std::log(x1);
@@ -3266,14 +3266,14 @@ BOOST_AUTO_TEST_CASE(customPow_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3284,9 +3284,9 @@ BOOST_AUTO_TEST_CASE(customPow_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3304,8 +3304,8 @@ BOOST_AUTO_TEST_CASE(customPow_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   double x1 = -1.1, x2 = -4.53, x3 = 3.03, x4 = 0.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -3313,7 +3313,7 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -3322,7 +3322,7 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   ay1 = exp(ax1 + 3. * ax2 + 5. * ax3 + 7. * ax4);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::exp(x1 + 3. * x2 + 5. * x3 + 7. * x4);
   double y1x2Derivative = 3. * std::exp(x1 + 3. * x2 + 5. * x3 + 7. * x4);
@@ -3360,14 +3360,14 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(4, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3384,9 +3384,9 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3403,9 +3403,9 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   xd[2] = 1.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3422,9 +3422,9 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 1.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3446,21 +3446,21 @@ BOOST_AUTO_TEST_CASE(customExpSum_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customHypErf_HOS_Reverse) {
   double x1 = 5.55, x2 = 9.99;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = exp(tanh(ax1) * erf(ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::exp(std::tanh(x1) * std::erf(x2)) *
                           (1. - std::pow(std::tanh(x1), 2)) * std::erf(x2);
@@ -3495,14 +3495,14 @@ BOOST_AUTO_TEST_CASE(customHypErf_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3513,9 +3513,9 @@ BOOST_AUTO_TEST_CASE(customHypErf_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3533,21 +3533,21 @@ BOOST_AUTO_TEST_CASE(customHypErf_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customHypAtan_HOS_Reverse) {
   double x1 = 7.19, x2 = -4.32;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = (pow(cosh(ax1), 2) - pow(sinh(ax1), 2)) * atan(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0;
   double y1x2Derivative = 1. / (1. + x2 * x2);
@@ -3567,14 +3567,14 @@ BOOST_AUTO_TEST_CASE(customHypAtan_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3585,9 +3585,9 @@ BOOST_AUTO_TEST_CASE(customHypAtan_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3605,15 +3605,15 @@ BOOST_AUTO_TEST_CASE(customHypAtan_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
   double x1 = 99.99, x2 = std::exp(-0.44), x3 = std::sqrt(2);
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -3622,7 +3622,7 @@ BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
         ax3 * ax3 * ax3 * ax3;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 1. + 2. * x1;
   double y1x2Derivative = 2. * x2 + 3. * x2 * x2;
@@ -3650,14 +3650,14 @@ BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(3, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3671,9 +3671,9 @@ BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3687,9 +3687,9 @@ BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3709,15 +3709,15 @@ BOOST_AUTO_TEST_CASE(customLongSum_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
   double x1 = -0.77, x2 = 10.01, x3 = 0.99;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -3725,7 +3725,7 @@ BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
   ay1 = exp(ax1) * sqrt(2. * ax2) * pow(ax3, 2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::exp(x1) * std::sqrt(2. * x2) * std::pow(x3, 2);
   double y1x2Derivative = std::exp(x1) * std::pow(x3, 2) / std::sqrt(2. * x2);
@@ -3754,14 +3754,14 @@ BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(3, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3775,9 +3775,9 @@ BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3791,9 +3791,9 @@ BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3813,21 +3813,21 @@ BOOST_AUTO_TEST_CASE(customExpSqrt_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customInvHyperb_HOS_Reverse) {
   double x1 = -3.03, x2 = 0.11;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = 2. * acosh(cosh(ax1 * ax1)) * atanh(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 4. * x1 * std::atanh(x2);
   double y1x2Derivative = 2. * x1 * x1 / (1. - x2 * x2);
@@ -3847,14 +3847,14 @@ BOOST_AUTO_TEST_CASE(customInvHyperb_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3865,9 +3865,9 @@ BOOST_AUTO_TEST_CASE(customInvHyperb_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3885,8 +3885,8 @@ BOOST_AUTO_TEST_CASE(customInvHyperb_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   double x1 = 1., x2 = 2.5, x3 = -4.5, x4 = -1.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -3894,7 +3894,7 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -3903,7 +3903,7 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   ay1 = fmax(fmin(ax1, ax2), fabs(ax3)) * ax4;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.;
   double y1x2Derivative = 0.;
@@ -3941,14 +3941,14 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(4, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3965,9 +3965,9 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -3984,9 +3984,9 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   xd[2] = 1.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4003,9 +4003,9 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 1.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4027,8 +4027,8 @@ BOOST_AUTO_TEST_CASE(customFminFmaxFabs_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   double x1 = 1., x2 = 2.5, x3 = -4.5, x4 = -1.;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -4036,7 +4036,7 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -4045,7 +4045,7 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   ay1 = max(min(ax1, ax2), abs(ax3)) * ax4;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.;
   double y1x2Derivative = 0.;
@@ -4083,14 +4083,14 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(4, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4107,9 +4107,9 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4126,9 +4126,9 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   xd[2] = 1.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4145,9 +4145,9 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 1.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4169,8 +4169,8 @@ BOOST_AUTO_TEST_CASE(customMinMaxAbs_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   double x1 = 0.11, x2 = 0.33, x3 = 0.1 * std::acos(0.), x4 = std::exp(-1.);
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -4178,7 +4178,7 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -4187,7 +4187,7 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   ay1 = 3. * asin(sin(ax1 + ax2)) * sin(ax3) * cos(ax4);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 3. * std::sin(x3) * std::cos(x4);
   double y1x2Derivative = 3. * std::sin(x3) * std::cos(x4);
@@ -4225,14 +4225,14 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(4, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4249,9 +4249,9 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4268,9 +4268,9 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   xd[2] = 1.;
   xd[3] = 0.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4287,9 +4287,9 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
   xd[2] = 0.;
   xd[3] = 1.;
 
-  fos_forward(tapeId, 1, 4, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 4, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 4, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 4, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4311,21 +4311,21 @@ BOOST_AUTO_TEST_CASE(customInvTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customInvTrig2_HOS_Reverse) {
   double x1 = 0.53, x2 = -0.01;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = atan(ax1) * asin(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::asin(x2) / (1. + x1 * x1);
   double y1x2Derivative = std::atan(x1) / std::sqrt(1. - x2 * x2);
@@ -4347,14 +4347,14 @@ BOOST_AUTO_TEST_CASE(customInvTrig2_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4365,9 +4365,9 @@ BOOST_AUTO_TEST_CASE(customInvTrig2_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4385,21 +4385,21 @@ BOOST_AUTO_TEST_CASE(customInvTrig2_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customFabsFmax_HOS_Reverse) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = fmax(fabs(ax1 * ax1), fabs(ax2 * ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 2. * x1;
   double y1x2Derivative = 0.;
@@ -4419,14 +4419,14 @@ BOOST_AUTO_TEST_CASE(customFabsFmax_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4437,9 +4437,9 @@ BOOST_AUTO_TEST_CASE(customFabsFmax_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4457,21 +4457,21 @@ BOOST_AUTO_TEST_CASE(customFabsFmax_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customAbsMax_HOS_Reverse) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = max(abs(ax1 * ax1), abs(ax2 * ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 2. * x1;
   double y1x2Derivative = 0.;
@@ -4491,14 +4491,14 @@ BOOST_AUTO_TEST_CASE(customAbsMax_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4509,9 +4509,9 @@ BOOST_AUTO_TEST_CASE(customAbsMax_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4529,21 +4529,21 @@ BOOST_AUTO_TEST_CASE(customAbsMax_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customFabsFmin_HOS_Reverse) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = fmin(fabs(ax1 * ax1), fabs(ax2 * ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.;
   double y1x2Derivative = 2. * x2;
@@ -4563,14 +4563,14 @@ BOOST_AUTO_TEST_CASE(customFabsFmin_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4581,9 +4581,9 @@ BOOST_AUTO_TEST_CASE(customFabsFmin_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4601,21 +4601,21 @@ BOOST_AUTO_TEST_CASE(customFabsFmin_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customAbsMin_HOS_Reverse) {
   double x1 = 9.9, x2 = -4.7;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = min(abs(ax1 * ax1), abs(ax2 * ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.;
   double y1x2Derivative = 2. * x2;
@@ -4635,14 +4635,14 @@ BOOST_AUTO_TEST_CASE(customAbsMin_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4653,9 +4653,9 @@ BOOST_AUTO_TEST_CASE(customAbsMin_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4673,21 +4673,21 @@ BOOST_AUTO_TEST_CASE(customAbsMin_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customFmaxTrig_HOS_Reverse) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = fmax(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2) * exp(ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 2. * x1 * std::cos(x2);
   double y1x2Derivative = -x1 * x1 * std::sin(x2);
@@ -4707,14 +4707,14 @@ BOOST_AUTO_TEST_CASE(customFmaxTrig_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4725,9 +4725,9 @@ BOOST_AUTO_TEST_CASE(customFmaxTrig_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4745,21 +4745,21 @@ BOOST_AUTO_TEST_CASE(customFmaxTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customMaxTrig_HOS_Reverse) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = max(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2) * exp(ax2));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 2. * x1 * std::cos(x2);
   double y1x2Derivative = -x1 * x1 * std::sin(x2);
@@ -4779,14 +4779,14 @@ BOOST_AUTO_TEST_CASE(customMaxTrig_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4797,9 +4797,9 @@ BOOST_AUTO_TEST_CASE(customMaxTrig_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4817,21 +4817,21 @@ BOOST_AUTO_TEST_CASE(customMaxTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customFminTrig_HOS_Reverse) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = fmin(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2 * exp(ax2)));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x1) * std::cos(x2 * std::exp(x2));
   double y1x2Derivative =
@@ -4857,14 +4857,14 @@ BOOST_AUTO_TEST_CASE(customFminTrig_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4875,9 +4875,9 @@ BOOST_AUTO_TEST_CASE(customFminTrig_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4895,21 +4895,21 @@ BOOST_AUTO_TEST_CASE(customFminTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customMinTrig_HOS_Reverse) {
   double x1 = 21.07, x2 = 1.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = min(ax1 * ax1 * cos(ax2), sin(ax1) * cos(ax2 * exp(ax2)));
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x1) * std::cos(x2 * std::exp(x2));
   double y1x2Derivative =
@@ -4935,14 +4935,14 @@ BOOST_AUTO_TEST_CASE(customMinTrig_HOS_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(2, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4953,9 +4953,9 @@ BOOST_AUTO_TEST_CASE(customMinTrig_HOS_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 2, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 2, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -4973,15 +4973,15 @@ BOOST_AUTO_TEST_CASE(customMinTrig_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
   double x1 = -5.2, x2 = 1.1, x3 = 5.4;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -4989,7 +4989,7 @@ BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
   ay1 = pow(ax1, 3) * pow(ax2, 4) * exp(tan(ax3)) + ax3 + sqrt(11);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative =
       3. * std::pow(x1, 2) * std::pow(x2, 4) * std::exp(std::tan(x3));
@@ -5034,14 +5034,14 @@ BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(3, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5055,9 +5055,9 @@ BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5071,9 +5071,9 @@ BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 1, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 3, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5093,8 +5093,8 @@ BOOST_AUTO_TEST_CASE(customPowExpTan_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   double x1 = 1.5, x2 = -1.5, x3 = 3., x4 = -3., x5 = 4.5, x6 = -4.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -5104,7 +5104,7 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -5116,7 +5116,7 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
         (ax1 * ax1 + ax2 * ax2 + ax3 * ax3 + ax4 * ax4 + ax5 * ax5 + ax6 * ax6);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = x1;
   double y1x2Derivative = x2;
@@ -5180,14 +5180,14 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(6, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5210,9 +5210,9 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5235,9 +5235,9 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5260,9 +5260,9 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5285,9 +5285,9 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 1.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5310,9 +5310,9 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 1.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5338,8 +5338,8 @@ BOOST_AUTO_TEST_CASE(customManyVariabl_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   double x1 = 1.5, x2 = -1.5, x3 = 3., x4 = -3., x5 = 4.5, x6 = -4.5;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -5349,7 +5349,7 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -5360,7 +5360,7 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   ay1 = 0.001001;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 0.;
   double y1x2Derivative = 0.;
@@ -5424,14 +5424,14 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
   double *u = myalloc1(1);
   double **Z = myalloc2(6, 2);
 
   u[0] = 1.;
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5454,9 +5454,9 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5479,9 +5479,9 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5504,9 +5504,9 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5529,9 +5529,9 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 1.;
   xd[5] = 0.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5554,9 +5554,9 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
   xd[4] = 0.;
   xd[5] = 1.;
 
-  fos_forward(tapeId, 1, 6, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 6, 2, x, xd, y, yd);
 
-  hos_reverse(tapeId, 1, 6, 1, u, Z);
+  hos_reverse(*tapePtr, 1, 6, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5582,8 +5582,8 @@ BOOST_AUTO_TEST_CASE(customConstant_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   double x1 = 21.87, x2 = std::acos(0) - 0.01, x3 = 0.5 * std::acos(0);
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -5592,7 +5592,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -5604,7 +5604,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   ay1 >>= y1;
   ay2 >>= y2;
   ay3 >>= y3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2) * std::sin(x3);
   double y1x2Derivative = -x1 * std::sin(x2) * std::sin(x3);
@@ -5656,7 +5656,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(3);
   double **Z = myalloc2(3, 2);
@@ -5665,7 +5665,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5679,7 +5679,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -5693,7 +5693,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));
@@ -5707,13 +5707,13 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5727,7 +5727,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -5741,7 +5741,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));
@@ -5755,13 +5755,13 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5775,7 +5775,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -5789,7 +5789,7 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));
@@ -5809,8 +5809,8 @@ BOOST_AUTO_TEST_CASE(customSphereCoord_HOS_Reverse) {
 
 BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   double x1 = 21.87, x2 = std::acos(0) - 0.01, x3 = 105.05;
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   adouble ax1;
   adouble ax2;
   adouble ax3;
@@ -5819,7 +5819,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   adouble ay2;
   adouble ay3;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
   ax3 <<= x3;
@@ -5831,7 +5831,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   ay1 >>= y1;
   ay2 >>= y2;
   ay3 >>= y3;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = std::cos(x2);
   double y1x2Derivative = -x1 * std::sin(x2);
@@ -5883,7 +5883,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   double *u = myalloc1(3);
   double **Z = myalloc2(3, 2);
@@ -5892,7 +5892,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5906,7 +5906,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -5920,7 +5920,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));
@@ -5934,13 +5934,13 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   xd[1] = 1.;
   xd[2] = 0.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -5954,7 +5954,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -5968,7 +5968,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));
@@ -5982,13 +5982,13 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   xd[1] = 0.;
   xd[2] = 1.;
 
-  fos_forward(tapeId, 3, 3, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 3, 3, 2, x, xd, y, yd);
 
   u[0] = 1.;
   u[1] = 0.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -6002,7 +6002,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 1.;
   u[2] = 0.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y2x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y2x2Derivative, tt::tolerance(tol));
@@ -6016,7 +6016,7 @@ BOOST_AUTO_TEST_CASE(customCylinderCoord_HOS_Reverse) {
   u[1] = 0.;
   u[2] = 1.;
 
-  hos_reverse(tapeId, 3, 3, 1, u, Z);
+  hos_reverse(*tapePtr, 3, 3, 1, u, Z);
 
   BOOST_TEST(Z[0][0] == y3x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[1][0] == y3x2Derivative, tt::tolerance(tol));

--- a/ADOL-C/boost-test/traceSecOrderVector.cpp
+++ b/ADOL-C/boost-test/traceSecOrderVector.cpp
@@ -33,20 +33,20 @@ BOOST_AUTO_TEST_SUITE(trace_sec_order_vec)
 
 BOOST_AUTO_TEST_CASE(CustomCube_HOV_Forward) {
 
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   double x1 = 3.;
   adouble ax1;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
 
   ay1 = 2. * ax1 * ax1 * ax1;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *yprim;
   yprim = myalloc1(1);
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(CustomCube_HOV_Forward) {
   double ***Y;
   Y = myalloc3(1, 3, 2);
 
-  hov_forward(tapeId, 1, 1, 2, 3, x, X, y, Y);
+  hov_forward(*tapePtr, 1, 1, 2, 3, x, X, y, Y);
 
   BOOST_TEST(y[0] == yprim[0], tt::tolerance(tol));
   BOOST_TEST(Y[0][0][0] == yDerivative[0][0][0], tt::tolerance(tol));
@@ -101,20 +101,20 @@ BOOST_AUTO_TEST_CASE(CustomCube_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(customCube_HOV_Reverse) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   double x1 = 3.;
   adouble ax1;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
 
   ay1 = 2. * ax1 * ax1 * ax1;
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = 6. * x1 * x1;
 
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(customCube_HOV_Reverse) {
   x[0] = 3.;
   xd[0] = 1.;
 
-  fos_forward(tapeId, 1, 1, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 1, 2, x, xd, y, yd);
 
   double **U = myalloc2(2, 1);
   double ***Z = myalloc3(2, 1, 2);
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(customCube_HOV_Reverse) {
   U[0][0] = 1.;
   U[1][0] = 5.;
 
-  hov_reverse(tapeId, 1, 1, 1, 2, U, Z, nz);
+  hov_reverse(*tapePtr, 1, 1, 1, 2, U, Z, nz);
 
   BOOST_TEST(Z[0][0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[0][0][1] == y1x1x1Derivative, tt::tolerance(tol));
@@ -167,22 +167,22 @@ BOOST_AUTO_TEST_CASE(customCube_HOV_Reverse) {
  *                      -sin(x1)*cos(x2), -cos(x1)*sin(x2))
  */
 BOOST_AUTO_TEST_CASE(CustomTrigProd_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   double x1 = 1.3, x2 = 3.1;
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = cos(ax1) * sin(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double *yprim;
   yprim = myalloc1(1);
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(CustomTrigProd_HOV_Forward) {
   double ***Y;
   Y = myalloc3(1, 3, 2);
 
-  hov_forward(tapeId, 1, 2, 2, 3, x, X, y, Y);
+  hov_forward(*tapePtr, 1, 2, 2, 3, x, X, y, Y);
 
   BOOST_TEST(y[0] == yprim[0], tt::tolerance(tol));
   BOOST_TEST(Y[0][0][0] == yDerivative[0][0][0], tt::tolerance(tol));
@@ -251,22 +251,22 @@ BOOST_AUTO_TEST_CASE(CustomTrigProd_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(customTrigProd_HOV_Reverse) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   double x1 = 1.3, x2 = 3.1;
   adouble ax1;
   adouble ax2;
   double y1;
   adouble ay1;
 
-  trace_on(tapeId, 1);
+  trace_on(*tapePtr, 1);
   ax1 <<= x1;
   ax2 <<= x2;
 
   ay1 = cos(ax1) * sin(ax2);
 
   ay1 >>= y1;
-  trace_off();
+  trace_off(*tapePtr);
 
   double y1x1Derivative = -std::sin(x1) * std::sin(x2);
   double y1x2Derivative = std::cos(x1) * std::cos(x2);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOV_Reverse) {
   xd[0] = 1.;
   xd[1] = 0.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
   double **U = myalloc2(2, 1);
   double ***Z = myalloc3(2, 2, 2);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOV_Reverse) {
   U[0][0] = 1.;
   U[1][0] = 5.;
 
-  hov_reverse(tapeId, 1, 2, 1, 2, U, Z, nz);
+  hov_reverse(*tapePtr, 1, 2, 1, 2, U, Z, nz);
 
   BOOST_TEST(Z[0][0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[0][1][0] == y1x2Derivative, tt::tolerance(tol));
@@ -316,9 +316,9 @@ BOOST_AUTO_TEST_CASE(customTrigProd_HOV_Reverse) {
   xd[0] = 0.;
   xd[1] = 1.;
 
-  fos_forward(tapeId, 1, 2, 2, x, xd, y, yd);
+  fos_forward(*tapePtr, 1, 2, 2, x, xd, y, yd);
 
-  hov_reverse(tapeId, 1, 2, 1, 2, U, Z, nz);
+  hov_reverse(*tapePtr, 1, 2, 1, 2, U, Z, nz);
 
   BOOST_TEST(Z[0][0][0] == y1x1Derivative, tt::tolerance(tol));
   BOOST_TEST(Z[0][1][0] == y1x2Derivative, tt::tolerance(tol));

--- a/ADOL-C/boost-test/uni5_for/hov_forward.cpp
+++ b/ADOL-C/boost-test/uni5_for/hov_forward.cpp
@@ -19,8 +19,8 @@ namespace tt = boost::test_tools;
 BOOST_AUTO_TEST_SUITE(test_hov_forward)
 
 BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
   adouble dep = fmax(pow(indep[0], 2), pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
   // max(x^2, y^3)
   double test_out = std::fmax(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::fmax(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -179,8 +179,8 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
   adouble dep = max(pow(indep[0], 2), pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
   // max(x^2, y^3)
   double test_out = std::max(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::max(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -339,8 +339,8 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
   adouble dep = fmin(-pow(indep[0], 2), -pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
   double test_out =
       std::fmin(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::fmin(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -500,8 +500,8 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
   adouble dep = min(-pow(indep[0], 2), -pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
   double test_out =
       std::min(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::min(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -661,8 +661,8 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(ExpOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -672,11 +672,11 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // exp(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = exp(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -695,7 +695,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_Forward) {
   // exp(x1^2)
   double test_out = std::exp(std::pow(in[0], 2));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -756,8 +756,8 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -767,12 +767,12 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 * x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) * pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -798,7 +798,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
   // x1^2 * x2^3
   double test_out = std::pow(test_in[0], 2) * std::pow(test_in[1], 3);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -883,8 +883,8 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -894,12 +894,12 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 + x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) + pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
   // x1^2 + x2^3
   double test_out = std::pow(test_in[0], 2) + std::pow(test_in[1], 3);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -972,8 +972,8 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -983,12 +983,12 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 - x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) - pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1014,7 +1014,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
   // x1^2 - x2^3
   double test_out = std::pow(test_in[0], 2) - std::pow(test_in[1], 3);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1061,8 +1061,8 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -1072,12 +1072,12 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 / x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) / pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1103,7 +1103,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
   // x1^2 - x2^3
   double test_out = std::pow(test_in[0], 2) / std::pow(test_in[1], 3);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1196,8 +1196,8 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1207,11 +1207,11 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // tan(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = tan(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1229,7 +1229,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
   // tan(x1^2)
   double test_out = std::tan(std::pow(test_in[0], 2));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1328,8 +1328,8 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1339,11 +1339,11 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sin(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sin(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1361,7 +1361,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
   // sin(x1^2)
   double test_out = std::sin(std::pow(test_in[0], 2));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1424,8 +1424,8 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1435,11 +1435,11 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cos(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cos(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1457,7 +1457,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
   // cos(x1^2)
   double test_out = std::cos(std::pow(test_in[0], 2));
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1520,8 +1520,8 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1531,11 +1531,11 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sqrt(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sqrt(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1553,7 +1553,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
   // sqrt(x)
   double test_out = std::sqrt(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1600,8 +1600,8 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1611,11 +1611,11 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // Log(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = log(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1633,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
   // log(x)
   double test_out = std::log(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1672,8 +1672,8 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1683,11 +1683,11 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sinh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sinh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1705,7 +1705,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
   // sinh(x)
   double test_out = std::sinh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1744,8 +1744,8 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1755,11 +1755,11 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cosh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cosh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1777,7 +1777,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
   // cosh(x)
   double test_out = std::cosh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1816,8 +1816,8 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1827,11 +1827,11 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // tanh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = tanh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1849,7 +1849,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   // tanh(x)
   double test_out = std::tanh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1905,8 +1905,8 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   myfree3(Y);
 }
 BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1916,11 +1916,11 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // asin(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = asin(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1938,7 +1938,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
   // asin(x)
   double test_out = std::asin(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1991,8 +1991,8 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2002,11 +2002,11 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // acos(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = acos(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2024,7 +2024,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
   // acos(x)
   double test_out = std::acos(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2077,8 +2077,8 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2088,11 +2088,11 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atan(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = atan(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2110,7 +2110,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
   // atan(x)
   double test_out = std::atan(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2159,8 +2159,8 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2170,11 +2170,11 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // log10(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = log10(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2192,7 +2192,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
   // log10(x)
   double test_out = std::log10(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2236,8 +2236,8 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2247,11 +2247,11 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // asinh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = asinh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2269,7 +2269,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
   // asinh(x)
   double test_out = std::asinh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2322,8 +2322,8 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2333,11 +2333,11 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // acosh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = acosh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2355,7 +2355,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
   // acosh(x)
   double test_out = std::acosh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2418,8 +2418,8 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2429,11 +2429,11 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atanh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = atanh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2451,7 +2451,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
   // atanh(x)
   double test_out = std::atanh(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2498,8 +2498,8 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2510,11 +2510,11 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
   adouble dep;
 
   // x + 1
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = ++indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2534,7 +2534,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
 
   // change the value back, since the operator increases test_in[0]
   test_in[0] = 0.2;
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2555,8 +2555,8 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2567,11 +2567,11 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
   adouble dep;
 
   // x - 1
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = --indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2591,7 +2591,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
 
   // change the value back, since the operator increases test_in[0]
   test_in[0] = 0.2;
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2612,8 +2612,8 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2624,11 +2624,11 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
   adouble dep;
 
   // x
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = +indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2646,7 +2646,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
   // x
   double test_out = +test_in[0];
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2667,8 +2667,8 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2679,11 +2679,11 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
   adouble dep;
 
   //-x
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = -indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2701,7 +2701,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
   // -x
   double test_out = -test_in[0];
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2722,8 +2722,8 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -2733,12 +2733,12 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atan2(x, y)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = atan2(indep[0], indep[1]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2764,7 +2764,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
   // atan2(x, y)
   double test_out = std::atan2(test_in[0], test_in[1]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2923,8 +2923,8 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2934,11 +2934,11 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = pow(indep[0], 3.2);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2956,7 +2956,7 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
   // x^y
   double test_out = std::pow(test_in[0], 3.2);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2995,8 +2995,8 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
 }
 
 BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -3006,12 +3006,12 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], indep[1]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3037,7 +3037,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
   // x^y
   double test_out = std::pow(test_in[0], test_in[1]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -3146,8 +3146,8 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
 }
 
 BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -3157,11 +3157,11 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = pow(1.5, indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3179,7 +3179,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
   // x^y
   double test_out = std::pow(1.5, test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -3231,11 +3231,11 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cbrt(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cbrt(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3253,7 +3253,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_HOV_Forward) {
   // cbrt(x)
   double test_out = std::cbrt(test_in[0]);
 
-  hov_forward(tapeId, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
+  hov_forward(*tapePtr, dim_out, dim_in, degree, num_dirs, test_in.data(), X,
               out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));

--- a/ADOL-C/boost-test/uni5_for/hov_wk_forward.cpp
+++ b/ADOL-C/boost-test/uni5_for/hov_wk_forward.cpp
@@ -19,8 +19,8 @@ namespace tt = boost::test_tools;
 BOOST_AUTO_TEST_SUITE(test_hov_wk_forward)
 
 BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
   adouble dep = fmax(pow(indep[0], 2), pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
   // max(x^2, y^3)
   double test_out = std::fmax(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::fmax(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -180,8 +180,8 @@ BOOST_AUTO_TEST_CASE(FmaxOperator_HOV_WK_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
   adouble dep = max(pow(indep[0], 2), pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
   // max(x^2, y^3)
   double test_out = std::max(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::max(std::pow(test_in[0], 2), std::pow(test_in[1], 3));
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -341,8 +341,8 @@ BOOST_AUTO_TEST_CASE(MaxOperator_HOV_WK_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
   adouble dep = fmin(-pow(indep[0], 2), -pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
   double test_out =
       std::fmin(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::fmin(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -503,8 +503,8 @@ BOOST_AUTO_TEST_CASE(FminOperator_HOV_WK_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 2;
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
   std::vector<adouble> indep(dim_in);
   std::vector<double> out(dim_out);
 
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   for (size_t i = 0; i < in.size(); i++) {
     indep[i] <<= in[i];
   }
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
   adouble dep = min(-pow(indep[0], 2), -pow(indep[1], 3));
 
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
   double test_out =
       std::min(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
   test_in[1] = 1.0;
   // max(x^2, y^3)
   test_out = std::min(-std::pow(test_in[0], 2), -std::pow(test_in[1], 3));
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -634,7 +634,7 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
   X[0][2][1] = 1.0;
   X[1][2][1] = 2.0;
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
@@ -665,8 +665,8 @@ BOOST_AUTO_TEST_CASE(MinOperator_HOV_WK_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(ExpOperator_HOV_WK_FORWARD) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -677,11 +677,11 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_WK_FORWARD) {
   std::vector<double> out(dim_out);
 
   // exp(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = exp(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_WK_FORWARD) {
   // exp(x1^2)
   double test_out = std::exp(std::pow(in[0], 2));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -760,8 +760,8 @@ BOOST_AUTO_TEST_CASE(ExpOperator_HOV_WK_FORWARD) {
   myfree3(Y);
 }
 BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -772,12 +772,12 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 * x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) * pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -803,7 +803,7 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
   // x1^2 * x2^3
   double test_out = std::pow(test_in[0], 2) * std::pow(test_in[1], 3);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -888,8 +888,8 @@ BOOST_AUTO_TEST_CASE(MultOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -900,12 +900,12 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 + x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) + pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -931,7 +931,7 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
   // x1^2 + x2^3
   double test_out = std::pow(test_in[0], 2) + std::pow(test_in[1], 3);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -978,8 +978,8 @@ BOOST_AUTO_TEST_CASE(AddOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -990,12 +990,12 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 - x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) - pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
   // x1^2 - x2^3
   double test_out = std::pow(test_in[0], 2) - std::pow(test_in[1], 3);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1068,8 +1068,8 @@ BOOST_AUTO_TEST_CASE(SubOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -1080,12 +1080,12 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // x1^2 / x2^3
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], 2) / pow(indep[1], 3);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1111,7 +1111,7 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
   // x1^2 - x2^3
   double test_out = std::pow(test_in[0], 2) / std::pow(test_in[1], 3);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1204,8 +1204,8 @@ BOOST_AUTO_TEST_CASE(DivOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1216,11 +1216,11 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // tan(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = tan(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1238,7 +1238,7 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
   // tan(x1^2)
   double test_out = std::tan(std::pow(test_in[0], 2));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1337,8 +1337,8 @@ BOOST_AUTO_TEST_CASE(TanOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1349,11 +1349,11 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sin(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sin(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1371,7 +1371,7 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
   // sin(x1^2)
   double test_out = std::sin(std::pow(test_in[0], 2));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1434,8 +1434,8 @@ BOOST_AUTO_TEST_CASE(SinOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1446,11 +1446,11 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cos(x1^2)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cos(pow(indep[0], 2));
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1468,7 +1468,7 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
   // cos(x1^2)
   double test_out = std::cos(std::pow(test_in[0], 2));
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1531,8 +1531,8 @@ BOOST_AUTO_TEST_CASE(CosOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1543,11 +1543,11 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sqrt(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sqrt(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1565,7 +1565,7 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
   // sqrt(x)
   double test_out = std::sqrt(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1612,8 +1612,8 @@ BOOST_AUTO_TEST_CASE(SqrtOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1624,11 +1624,11 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // Log(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = log(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1646,7 +1646,7 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
   // log(x)
   double test_out = std::log(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1685,8 +1685,8 @@ BOOST_AUTO_TEST_CASE(LogOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1697,11 +1697,11 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // sinh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = sinh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1719,7 +1719,7 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
   // sinh(x)
   double test_out = std::sinh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1758,8 +1758,8 @@ BOOST_AUTO_TEST_CASE(SinhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1770,11 +1770,11 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cosh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cosh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1792,7 +1792,7 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
   // cosh(x)
   double test_out = std::cosh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1830,8 +1830,8 @@ BOOST_AUTO_TEST_CASE(CoshOperator_HOV_Forward) {
   myfree3(Y);
 }
 BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1842,11 +1842,11 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // tanh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = tanh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1864,7 +1864,7 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   // tanh(x)
   double test_out = std::tanh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -1920,8 +1920,8 @@ BOOST_AUTO_TEST_CASE(TanhOperator_HOV_Forward) {
   myfree3(Y);
 }
 BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -1932,11 +1932,11 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // asin(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = asin(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -1954,7 +1954,7 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
   // asin(x)
   double test_out = std::asin(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2007,8 +2007,8 @@ BOOST_AUTO_TEST_CASE(AsinOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2019,11 +2019,11 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // acos(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = acos(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2041,7 +2041,7 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
   // acos(x)
   double test_out = std::acos(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2094,8 +2094,8 @@ BOOST_AUTO_TEST_CASE(AcosOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2106,11 +2106,11 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atan(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = atan(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2128,7 +2128,7 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
   // atan(x)
   double test_out = std::atan(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2177,8 +2177,8 @@ BOOST_AUTO_TEST_CASE(AtanOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2189,11 +2189,11 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // log10(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = log10(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2211,7 +2211,7 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
   // log10(x)
   double test_out = std::log10(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2255,8 +2255,8 @@ BOOST_AUTO_TEST_CASE(Log10Operator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2267,11 +2267,11 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // asinh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = asinh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2289,7 +2289,7 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
   // asinh(x)
   double test_out = std::asinh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2342,8 +2342,8 @@ BOOST_AUTO_TEST_CASE(AsinhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2354,11 +2354,11 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // acosh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = acosh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2376,7 +2376,7 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
   // acosh(x)
   double test_out = std::acosh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2439,8 +2439,8 @@ BOOST_AUTO_TEST_CASE(AcoshOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2451,11 +2451,11 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atanh(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = atanh(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2473,7 +2473,7 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
   // atanh(x)
   double test_out = std::atanh(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2520,8 +2520,8 @@ BOOST_AUTO_TEST_CASE(AtanhOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2533,11 +2533,11 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
   adouble dep;
 
   // x + 1
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = ++indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2557,7 +2557,7 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
 
   // change the value back, since the operator increases test_in[0]
   test_in[0] = 0.2;
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2578,8 +2578,8 @@ BOOST_AUTO_TEST_CASE(InclOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2591,11 +2591,11 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
   adouble dep;
 
   // x - 1
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = --indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2615,7 +2615,7 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
 
   // change the value back, since the operator increases test_in[0]
   test_in[0] = 0.2;
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2636,8 +2636,8 @@ BOOST_AUTO_TEST_CASE(DeclOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2649,11 +2649,11 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
   adouble dep;
 
   // x
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = +indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2673,7 +2673,7 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
 
   // change the value back, since the operator increases test_in[0]
   test_in[0] = 0.2;
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2694,8 +2694,8 @@ BOOST_AUTO_TEST_CASE(SignPlusOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2707,11 +2707,11 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
   adouble dep;
 
   //-x
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   dep = -indep[0];
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2729,7 +2729,7 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
   // -x
   double test_out = -test_in[0];
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2750,8 +2750,8 @@ BOOST_AUTO_TEST_CASE(SignMinusOperator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -2762,12 +2762,12 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // atan2(x, y)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = atan2(indep[0], indep[1]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2793,7 +2793,7 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
   // atan2(x, y)
   double test_out = std::atan2(test_in[0], test_in[1]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -2952,8 +2952,8 @@ BOOST_AUTO_TEST_CASE(Atan2Operator_HOV_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -2964,11 +2964,11 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = pow(indep[0], 3.2);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -2986,7 +2986,7 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
   // x^y
   double test_out = std::pow(test_in[0], 3.2);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -3024,8 +3024,8 @@ BOOST_AUTO_TEST_CASE(Pow_Operator_HOV_Forward_1) {
   myfree3(Y);
 }
 BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 2;
   const size_t degree = 3;
@@ -3036,12 +3036,12 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   indep[1] <<= in[1];
   adouble dep = pow(indep[0], indep[1]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3067,7 +3067,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
   // x^y
   double test_out = std::pow(test_in[0], test_in[1]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -3176,8 +3176,8 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_2) {
 }
 
 BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const size_t dim_out = 1;
   const size_t dim_in = 1;
   const size_t degree = 3;
@@ -3188,11 +3188,11 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
   std::vector<double> out(dim_out);
 
   // x^y
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = pow(1.5, indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3210,7 +3210,7 @@ BOOST_AUTO_TEST_CASE(PowOperator_HOV_Forward_3) {
   // x^y
   double test_out = std::pow(1.5, test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
                  test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
@@ -3264,11 +3264,11 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_HOV_Forward) {
   std::vector<double> out(dim_out);
 
   // cbrt(x)
-  trace_on(tapeId);
+  trace_on(*tapePtr);
   indep[0] <<= in[0];
   adouble dep = cbrt(indep[0]);
   dep >>= out[0];
-  trace_off();
+  trace_off(*tapePtr);
 
   double ***X = myalloc3(dim_in, num_dirs, degree);
   double ***Y = myalloc3(dim_out, num_dirs, degree);
@@ -3286,7 +3286,7 @@ BOOST_AUTO_TEST_CASE(CbrtOperator_HOV_Forward) {
   // cbrt(x)
   double test_out = std::cbrt(test_in[0]);
 
-  hov_wk_forward(tapeId, dim_out, dim_in, degree, keep, num_dirs,
+  hov_wk_forward(*tapePtr, dim_out, dim_in, degree, keep, num_dirs,
 test_in.data(), X, out.data(), Y);
 
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));

--- a/ADOL-C/boost-test/uni5_for/uni5_for.cpp
+++ b/ADOL-C/boost-test/uni5_for/uni5_for.cpp
@@ -19,8 +19,8 @@ namespace tt = boost::test_tools;
 BOOST_AUTO_TEST_SUITE(uni5_for)
 
 BOOST_AUTO_TEST_CASE(FAbsOperator_ZOS_PL_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const int dim_out = 1;
   const int dim_in = 3;
 
@@ -28,10 +28,10 @@ BOOST_AUTO_TEST_CASE(FAbsOperator_ZOS_PL_Forward) {
   std::array<adouble, dim_in> indep;
   double out[] = {0.0};
 
-  currentTape().enableMinMaxUsingAbs();
+  currentTapePtr()->enableMinMaxUsingAbs();
   // ---------------------- trace on ---------------------
   // function is given by fabs(in_2 + fabs(in_1 + fabs(in_0)))
-  trace_on(tapeId);
+  trace_on(*tapePtr);
 
   // init independents
   for (size_t i = 0; i < in.size(); i++) {
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(FAbsOperator_ZOS_PL_Forward) {
                       [](auto &&sum, auto &&val) { return fabs(sum + val); });
 
   dep >>= out[0];
-  trace_off();
-  currentTape().disableMinMaxUsingAbs();
+  trace_off(*tapePtr);
+  currentTapePtr()->disableMinMaxUsingAbs();
   // ---------------------- trace off ---------------------
 
   // test outout
@@ -56,12 +56,12 @@ BOOST_AUTO_TEST_CASE(FAbsOperator_ZOS_PL_Forward) {
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
   // test num switches
-  size_t num_switches = get_num_switches(tapeId);
+  size_t num_switches = get_num_switches(*tapePtr);
   BOOST_TEST(num_switches == dim_in, tt::tolerance(tol));
 
   const int keep = 0;
   std::vector<double> switching_vec(num_switches);
-  zos_pl_forward(tapeId, dim_out, dim_in, keep, in.data(), out,
+  zos_pl_forward(*tapePtr, dim_out, dim_in, keep, in.data(), out,
                  switching_vec.data());
 
   // test outout of zos_pl_forward
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE(FAbsOperator_ZOS_PL_Forward) {
 }
 
 BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_PL_Forward) {
-  const auto tapeId = createNewTape();
-  setCurrentTape(tapeId);
+  auto tapePtr = std::make_unique<ValueTape>();
+  setCurrentTapePtr(tapePtr.get());
   const int dim_out = 1;
   const int dim_in = 3;
 
@@ -88,10 +88,10 @@ BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_PL_Forward) {
   std::array<adouble, dim_in> indep;
   double out[] = {0.0};
 
-  currentTape().enableMinMaxUsingAbs();
+  currentTapePtr()->enableMinMaxUsingAbs();
   // ---------------------- trace on ---------------------
   // function is given by fabs(in_2 + fabs(in_1 + fabs(in_0)))
-  trace_on(tapeId);
+  trace_on(*tapePtr);
 
   // init independents
   for (size_t i = 0; i < in.size(); i++) {
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_PL_Forward) {
                       [](auto &&sum, auto &&val) { return abs(sum + val); });
 
   dep >>= out[0];
-  trace_off();
-  currentTape().disableMinMaxUsingAbs();
+  trace_off(*tapePtr);
+  currentTapePtr()->disableMinMaxUsingAbs();
   // ---------------------- trace off ---------------------
 
   // test outout
@@ -116,12 +116,12 @@ BOOST_AUTO_TEST_CASE(AbsOperator_ZOS_PL_Forward) {
   BOOST_TEST(out[0] == test_out, tt::tolerance(tol));
 
   // test num switches
-  size_t num_switches = get_num_switches(tapeId);
+  size_t num_switches = get_num_switches(*tapePtr);
   BOOST_TEST(num_switches == dim_in, tt::tolerance(tol));
 
   const int keep = 0;
   std::vector<double> switching_vec(num_switches);
-  zos_pl_forward(tapeId, dim_out, dim_in, keep, in.data(), out,
+  zos_pl_forward(*tapePtr, dim_out, dim_in, keep, in.data(), out,
                  switching_vec.data());
 
   // test outout of zos_pl_forward

--- a/ADOL-C/boost-test/valuetape/tapeinfos.cpp
+++ b/ADOL-C/boost-test/valuetape/tapeinfos.cpp
@@ -8,14 +8,8 @@
 
 BOOST_AUTO_TEST_SUITE(Test_TapeInfos)
 
-BOOST_AUTO_TEST_CASE(TestConstructorTapeId) {
-  TapeInfos ti(3);
-
-  BOOST_CHECK(ti.tapeId_ == 3);
-}
-
 BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
-  TapeInfos tp(3);
+  TapeInfos tp{};
   tp.numInds = 10;
   tp.numDeps = 11;
 
@@ -117,7 +111,6 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   //// ======= MOVE CONSTRUCTOR =========
   //======================================
   TapeInfos tp2(std::move(tp));
-  BOOST_CHECK_EQUAL(tp2.tapeId_, 3);
   BOOST_CHECK_EQUAL(tp2.numInds, 10);
   BOOST_CHECK_EQUAL(tp2.numDeps, 11);
   BOOST_CHECK_EQUAL(tp2.keepTaylors, 1);

--- a/ADOL-C/examples/additional_examples/openmp_exam/liborpar.cpp
+++ b/ADOL-C/examples/additional_examples/openmp_exam/liborpar.cpp
@@ -153,7 +153,7 @@ int main() {
 #pragma omp parallel
   {
     const auto init = createNewTape();
-    setCurrentTape(init);
+    setCurrentTapePtr(init);
     int l, k;
     int rv = 0;
 

--- a/ADOL-C/examples/detexam.cpp
+++ b/ADOL-C/examples/detexam.cpp
@@ -60,7 +60,7 @@ adouble det(const T &A, size_t row,
 /****************************************************************************/
 /*                                                             MAIN PROGRAM */
 int main() {
-  const short tapeId = createNewTape();
+  const auto tapePtr = std::make_unique<ValueTape>();
 
   const int keep = 1;
   constexpr size_t n = 7;
@@ -68,7 +68,7 @@ int main() {
 
   std::array<std::array<adouble, n>, n> A;
 
-  trace_on(tapeId, keep); // tapeId=1=keep
+  trace_on(*tapePtr, keep); // *tapePtr=1=keep
   double detout = 0.0;
   double diag = 1.0;             // here keep the intermediates for
   for (size_t i = 0; i < n; i++) // the subsequent call to reverse
@@ -85,13 +85,13 @@ int main() {
 
   ad >>= detout;
   printf("\n %f - %f = %f  (should be 0)\n", detout, diag, detout - diag);
-  trace_off();
+  trace_off(*tapePtr);
 
   std::array<double, 1> u;
   u[0] = 1.0;
   std::array<double, n * n> B;
 
-  reverse(tapeId, 1, n * n, 0, u.data(),
+  reverse(*tapePtr, 1, n * n, 0, u.data(),
           B.data()); // call reverse to calculate the gradient
 
   std::cout << " \n first base? : ";

--- a/ADOL-C/examples/odexam.cpp
+++ b/ADOL-C/examples/odexam.cpp
@@ -16,6 +16,7 @@
 
 /****************************************************************************/
 /*                                                                 INCLUDES */
+#include "adolc/valuetape/valuetape.h"
 #include <adolc/adalloc.h>            // use of ADOL-C allocation utilities
 #include <adolc/adtb_types.h>         // use of active double
 #include <adolc/drivers/odedrivers.h> // use of "Easy To Use" ODE drivers
@@ -32,11 +33,11 @@ using namespace std;
 
 /****************************************************************************/
 /*                                                          ADOUBLE ROUTINE */
-void tracerhs(short int tag, double *py, double *pyprime) {
+void tracerhs(ValueTape &tape, double *py, double *pyprime) {
   adouble y[3]; // we left the parameters passive
   adouble yprime[3];
 
-  trace_on(tag);
+  trace_on(tape);
   y[0] <<= py[0];
   y[1] <<= py[1];
   y[2] <<= py[2]; // initialize and mark independents
@@ -46,7 +47,7 @@ void tracerhs(short int tag, double *py, double *pyprime) {
   yprime[0] >>= pyprime[0];
   yprime[1] >>= pyprime[1];
   yprime[2] >>= pyprime[2]; // mark and pass dependents
-  trace_off(1);             // write tape array onto a file
+  trace_off(tape, 1);       // write tape array onto a file
 } // end tracerhs
 
 /****************************************************************************/
@@ -75,11 +76,11 @@ int main() {
     X[i][0] = py[i];              // and the Taylor coefficient;
     nz[i] = new short[n];         // set up sparsity array
   } // end for
-  const short tapeId = createNewTape();
-  tracerhs(1, py, pyp); // trace RHS with tag = 1
+  const auto tapePtr = std::make_unique<ValueTape>();
+  tracerhs(*tapePtr, py, pyp); // trace RHS with tag = 1
 
-  forode(tapeId, n, deg, X);             // compute deg coefficients
-  reverse(tapeId, n, n, deg - 1, Z, nz); // U defaults to the identity
+  forode(*tapePtr, n, deg, X);             // compute deg coefficients
+  reverse(*tapePtr, n, n, deg - 1, Z, nz); // U defaults to the identity
   accode(n, deg - 1, Z, B, nz);
 
   cout << "nonzero pattern:\n";

--- a/ADOL-C/examples/powexam.cpp
+++ b/ADOL-C/examples/powexam.cpp
@@ -15,6 +15,7 @@
 
 /****************************************************************************/
 /*                                                                 INCLUDES */
+#include "adolc/valuetape/valuetape.h"
 #include <adolc/adolc.h> /* use of ALL ADOL-C interfaces */
 
 #include <iostream>
@@ -46,7 +47,7 @@ adouble power(adouble x, int n) {
 /*                                                             MAIN PROGRAM */
 int main() {
   int i;
-  const short tag = createNewTape();
+  auto tapePtr = std::make_unique<ValueTape>();
   int n;
 
   cout << "COMPUTATION OF N-TH POWER (ADOL-C Documented Example)\n\n";
@@ -66,17 +67,17 @@ int main() {
 
   adouble y, x; /* declare active variables */
   /* beginning of active section */
-  trace_on(tag);   /* tag = 1 and keep = 0 */
-  x <<= X[0][0];   /* only one independent var */
-  y = power(x, n); /* actual function call */
-  y >>= Y[0][0];   /* only one dependent adouble */
-  trace_off();     /* no global adouble has died */
+  trace_on(*tapePtr);  /* *tapePtr = 1 and keep = 0 */
+  x <<= X[0][0];       /* only one independent var */
+  y = power(x, n);     /* actual function call */
+  y >>= Y[0][0];       /* only one dependent adouble */
+  trace_off(*tapePtr); /* no global adouble has died */
   /* end of active section */
   double u[1];                /* weighting vector */
   u[0] = 1;                   /* for reverse call */
   for (i = 0; i < n + 2; i++) /* note that keep = i+1 in call */
   {
-    forward(tag, 1, 1, i, i + 1, X, Y); /* evaluate the i-the derivative */
+    forward(*tapePtr, 1, 1, i, i + 1, X, Y); /* evaluate the i-the derivative */
     if (i == 0)
       cout << Y[0][i] << " - " << y.value() << " = " << Y[0][i] - y.value()
            << " (should be 0)\n";
@@ -85,7 +86,7 @@ int main() {
       cout << Y[0][i] << " - " << Z[0][i] << " = " << Y[0][i] - Z[0][i]
            << " (should be 0)\n";
     }
-    reverse(tag, 1, 1, i, u, Z); /* evaluate the (i+1)-st deriv. */
+    reverse(*tapePtr, 1, 1, i, u, Z); /* evaluate the (i+1)-st deriv. */
   } /* end for */
 
   return 1;

--- a/ADOL-C/examples/speelpenning.cpp
+++ b/ADOL-C/examples/speelpenning.cpp
@@ -25,7 +25,7 @@ using namespace std;
 /****************************************************************************/
 /*                                                             MAIN PROGRAM */
 int main() {
-  const short tapeId = createNewTape();
+  const auto tapePtr = std::make_unique<ValueTape>();
   constexpr size_t n = 7;
 
   double *xp = new double[n];
@@ -36,27 +36,27 @@ int main() {
   for (size_t i = 0; i < n; i++)
     xp[i] = (to_double(i) + 1.0) / (2.0 + to_double(i)); // some initialization
 
-  trace_on(tapeId); // tag = 1, keep = 0 by default
+  trace_on(*tapePtr); // tag = 1, keep = 0 by default
   for (size_t i = 0; i < n; i++) {
     x[i] <<= xp[i]; // or  x <<= xp outside the loop
     y *= x[i];
   } // end for
   y >>= yp;
   delete[] x;
-  trace_off();
+  trace_off(*tapePtr);
 
-  auto tape_stats = tapestats(tapeId); // reading of tape statistics
+  auto tape_stats = tapestats(*tapePtr); // reading of tape statistics
   cout << "maxlive " << tape_stats[TapeInfos::NUM_MAX_LIVES] << "\n";
   // ..... print other tape stats
 
   double *g = new double[n];
-  gradient(tapeId, n, xp, g); // gradient evaluation
+  gradient(*tapePtr, n, xp, g); // gradient evaluation
 
   double **H = new double *[n];
   for (size_t i = 0; i < n; i++)
     H[i] = new double[i + 1];
-  hessian(tapeId, n, xp, H); // H equals (n-1)g since g is
-  double errg = 0;           // homogeneous of degree n-1.
+  hessian(*tapePtr, n, xp, H); // H equals (n-1)g since g is
+  double errg = 0;             // homogeneous of degree n-1.
   double errh = 0;
   for (size_t i = 0; i < n; i++)
     errg += fabs(g[i] - yp / xp[i]); // vanishes analytically.

--- a/ADOL-C/include/adolc/adtb_types.h
+++ b/ADOL-C/include/adolc/adtb_types.h
@@ -76,9 +76,9 @@ template <adouble_or_pdouble T> class tape_location {
    */
   size_t next_loc() {
     if constexpr (std::is_same_v<T, adouble>)
-      return currentTape().next_loc();
+      return currentTapePtr()->next_loc();
     else
-      return currentTape().p_next_loc();
+      return currentTapePtr()->p_next_loc();
   }
 
   /**
@@ -91,11 +91,11 @@ template <adouble_or_pdouble T> class tape_location {
     assert(currentTapePtr() != nullptr &&
            "Tape was deleted before all adoubles are destroyed!");
     if constexpr (std::is_same_v<T, adouble>)
-      currentTape().free_loc(loc());
+      currentTapePtr()->free_loc(loc());
 
     // currently freeing the location of pdouble leads to errors
     // need to revisit the issue
-    // currentTape().p_free_loc(loc());
+    // currentTapePtr()->p_free_loc(loc());
   }
 
 public:
@@ -262,7 +262,7 @@ public:
    * @brief Retrieves the current value stored at the tape location.
    * @return The value of the `adouble` from the tape.
    */
-  double value() const { return currentTape().get_ad_value(loc()); }
+  double value() const { return currentTapePtr()->get_ad_value(loc()); }
 
   /**
    * @brief Retrieves the location of the `adouble` on the tape.
@@ -275,7 +275,9 @@ public:
    * @brief Updates the value stored at the tape location.
    * @param coval the new value to assign.
    */
-  void value(const double coval) { currentTape().set_ad_value(loc(), coval); }
+  void value(const double coval) {
+    currentTapePtr()->set_ad_value(loc(), coval);
+  }
 
   // Type Conversions
 
@@ -440,13 +442,13 @@ public:
    * @brief Retrieves the current value stored at the tape location.
    * @return The value of the `pdouble`.
    */
-  double value() const { return currentTape().get_pd_value(loc()); }
+  double value() const { return currentTapePtr()->get_pd_value(loc()); }
 
   /**
    * @brief Updates the value stored at the tape location.
    * @param pval The new value to assign.
    */
-  void value(const double pval) { currentTape().set_pd_value(loc(), pval); }
+  void value(const double pval) { currentTapePtr()->set_pd_value(loc(), pval); }
 };
 
 ADOLC_API std::ostream &operator<<(std::ostream &, const adouble &);

--- a/ADOL-C/include/adolc/advector.h
+++ b/ADOL-C/include/adolc/advector.h
@@ -64,10 +64,12 @@ public:
 
   size_t loc() const { return loc_; }
   size_t refloc() const { return refloc_; }
-  double refloc_value() const { return currentTape().get_ad_value(refloc_); }
-  double loc_value() const { return currentTape().get_ad_value(loc_); }
+  double refloc_value() const {
+    return currentTapePtr()->get_ad_value(refloc_);
+  }
+  double loc_value() const { return currentTapePtr()->get_ad_value(loc_); }
   void refloc_value(const double coval) {
-    currentTape().set_ad_value(refloc_, coval);
+    currentTapePtr()->set_ad_value(refloc_, coval);
   }
   operator adouble() const;
 
@@ -117,10 +119,10 @@ class ADOLC_API advector {
 public:
   advector() = default;
   explicit advector(size_t n)
-      : data_(currentTape().ensureContiguousLocations_(n)) {}
+      : data_(currentTapePtr()->ensureContiguousLocations_(n)) {}
 
   advector(const advector &ad_vec)
-      : data_(currentTape().ensureContiguousLocations_(ad_vec.size())) {
+      : data_(currentTapePtr()->ensureContiguousLocations_(ad_vec.size())) {
     adolc_vec_copy(data_.data(), ad_vec.data_.data(), ad_vec.size());
   }
 

--- a/ADOL-C/include/adolc/drivers/drivers.h
+++ b/ADOL-C/include/adolc/drivers/drivers.h
@@ -14,6 +14,7 @@
  recipient's acceptance of the terms of the accompanying license file.
 
 ----------------------------------------------------------------------------*/
+#include "adolc/valuetape/valuetape.h"
 #if !defined(ADOLC_DRIVERS_DRIVERS_H)
 #define ADOLC_DRIVERS_DRIVERS_H 1
 
@@ -21,87 +22,88 @@
 #include <adolc/internal/common.h>
 
 BEGIN_C_DECLS
-
+class ValueTape;
 /****************************************************************************/
 /*                         DRIVERS FOR OPTIMIZATION AND NONLINEAR EQUATIONS */
 
 /*--------------------------------------------------------------------------*/
 /*                                                                 function */
 /* function(tag, m, n, x[n], y[m])                                          */
-ADOLC_API int function(short, int, int, const double *, double *);
-ADOLC_API fint function_(fint *, fint *, fint *, fdouble *, fdouble *);
+ADOLC_API int function(ValueTape &, int, int, const double *, double *);
+ADOLC_API fint function_(ValueTape &, fint *, fint *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                 gradient */
 /* gradient(tag, n, x[n], g[n])                                             */
-ADOLC_API int gradient(short, int, const double *, double *);
-ADOLC_API fint gradient_(fint *, fint *, fdouble *, fdouble *);
+ADOLC_API int gradient(ValueTape &, int, const double *, double *);
+ADOLC_API fint gradient_(ValueTape &, fint *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                 jacobian */
 /* jacobian(tag, m, n, x[n], J[m][n])                                       */
-ADOLC_API int jacobian(short, int, int, const double *, double **);
-ADOLC_API fint jacobian_(fint *, fint *, fint *, fdouble *, fdouble *);
+ADOLC_API int jacobian(ValueTape &, int, int, const double *, double **);
+ADOLC_API fint jacobian_(ValueTape &, fint *, fint *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           large_jacobian */
 /* large_jacobian(tag, m, n, k, x[n], y[m], J[m][n])                        */
-ADOLC_API int large_jacobian(short, int, int, int, double *, double *,
+ADOLC_API int large_jacobian(ValueTape &, int, int, int, double *, double *,
                              double **);
-ADOLC_API fint large_jacobian_(fint *, fint *, fint *, fint *, fdouble *,
+ADOLC_API fint large_jacobian_(ValueTape &, fint *, fint *, fint *, fdouble *,
                                fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                         vector_jacobian  */
 /* vec_jac(tag, m, n, repeat, x[n], u[m], v[n])                             */
-ADOLC_API int vec_jac(short, int, int, int, const double *, const double *,
-                      double *);
-ADOLC_API fint vec_jac_(fint *, fint *, fint *, fint *, fdouble *,
+ADOLC_API int vec_jac(ValueTape &, int, int, int, const double *,
+                      const double *, double *);
+ADOLC_API fint vec_jac_(ValueTape &, fint *, fint *, fint *, fdouble *,
                         const fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                          jacobian_vector */
 /* jac_vec(tag, m, n, x[n], v[n], u[m]);                                    */
-ADOLC_API int jac_vec(short, int, int, const double *, const double *,
+ADOLC_API int jac_vec(ValueTape &, int, int, const double *, const double *,
                       double *);
-ADOLC_API fint jac_vec_(fint *, fint *, fint *, fdouble *, fdouble *,
+ADOLC_API fint jac_vec_(ValueTape &, fint *, fint *, fdouble *, fdouble *,
                         fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                  hessian */
 /* hessian(tag, n, x[n], lower triangle of H[n][n])                         */
 /* uses Hessian-vector product                                              */
-ADOLC_API int hessian(short, int, const double *, double **);
-ADOLC_API fint hessian_(fint *, fint *, fdouble *, fdouble *);
+ADOLC_API int hessian(ValueTape &, int, const double *, double **);
+ADOLC_API fint hessian_(ValueTape &, fint *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                 hessian2 */
 /* hessian2(tag, n, x[n], lower triangle of H[n][n])                        */
 /* uses Hessian-matrix product                                              */
-ADOLC_API int hessian2(short, int, double *, double **);
-ADOLC_API fint hessian2_(fint *, fint *, fdouble *, fdouble *);
+ADOLC_API int hessian2(ValueTape &, int, double *, double **);
+ADOLC_API fint hessian2_(ValueTape &, fint *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           hessian_vector */
 /* hess_vec(tag, n, x[n], v[n], w[n])                                       */
-ADOLC_API int hess_vec(short, int, const double *, const double *, double *);
-ADOLC_API fint hess_vec_(fint *, fint *, fdouble *, fdouble *, fdouble *);
+ADOLC_API int hess_vec(ValueTape &, int, const double *, const double *,
+                       double *);
+ADOLC_API fint hess_vec_(ValueTape &, fint *, fdouble *, fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           hessian_matrix */
 /* hess_mat(tag, n, q, x[n], V[n][q], W[n][q])                              */
-ADOLC_API int hess_mat(short, int, int, const double *, const double *const *,
-                       double **);
-ADOLC_API fint hess_mat_(fint *, fint *, fint *, fdouble *, fdouble **,
+ADOLC_API int hess_mat(ValueTape &, int, int, const double *,
+                       const double *const *, double **);
+ADOLC_API fint hess_mat_(ValueTape &, fint *, fint *, fdouble *, fdouble **,
                          fdouble **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                  lagrange_hessian_vector */
 /* lagra_hess_vec(tag, m, n, x[n], v[n], u[m], w[n])                        */
-ADOLC_API int lagra_hess_vec(short, int, int, const double *, const double *,
-                             const double *, double *);
-ADOLC_API fint lagra_hess_vec_(fint *, fint *, fint *, fdouble *, fdouble *,
-                               fdouble *, fdouble *);
+ADOLC_API int lagra_hess_vec(ValueTape &, int, int, const double *,
+                             const double *, const double *, double *);
+ADOLC_API fint lagra_hess_vec_(ValueTape &, fint *, fint *, fdouble *,
+                               fdouble *, fdouble *, fdouble *);
 
 END_C_DECLS
 

--- a/ADOL-C/include/adolc/drivers/odedrivers.h
+++ b/ADOL-C/include/adolc/drivers/odedrivers.h
@@ -22,15 +22,16 @@
 #include <adolc/internal/common.h>
 
 BEGIN_C_DECLS
-
+class ValueTape;
 /****************************************************************************/
 /*                                                         DRIVERS FOR ODEs */
 
 /*--------------------------------------------------------------------------*/
 /*                                                                  forodec */
 /* forodec(tag, n, tau, dold, dnew, X[n][d+1])                              */
-ADOLC_API int forodec(short, int, double, int, int, double **);
-ADOLC_API fint forodec_(fint *, fint *, fdouble *, fint *, fint *, fdouble *);
+ADOLC_API int forodec(ValueTape &, int, double, int, int, double **);
+ADOLC_API fint forodec_(ValueTape &, fint *, fdouble *, fint *, fint *,
+                        fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                  accodec */
@@ -51,14 +52,14 @@ END_C_DECLS
 /*--------------------------------------------------------------------------*/
 /*                                                                   forode */
 /* forode(tag, n, tau, dold, dnew, X[n][d+1])                               */
-ADOLC_API inline int forode(short tag,  // tape identifier
-                            int n,      // space dimension
-                            double tau, // scaling
+ADOLC_API inline int forode(ValueTape &tapePtr, // tape identifier
+                            int n,              // space dimension
+                            double tau,         // scaling
                             int dold,   // previous degree defaults to zero
                             int dnew,   // New degree of consistency
                             double **X) // Taylor series
 {
-  return forodec(tag, n, tau, dold, dnew, X);
+  return forodec(tapePtr, n, tau, dold, dnew, X);
 }
 
 /*--------------------------------------------------------------------------*/
@@ -66,8 +67,9 @@ ADOLC_API inline int forode(short tag,  // tape identifier
 /*        the scaling tau defaults to 1                                     */
 /*                                                                          */
 /*  forode(tag, n, dold, dnew, X[n][d+1])                                   */
-ADOLC_API inline int forode(short tag, int n, int dold, int dnew, double **X) {
-  return forodec(tag, n, 1.0, dold, dnew, X);
+ADOLC_API inline int forode(ValueTape &tapePtr, int n, int dold, int dnew,
+                            double **X) {
+  return forodec(tapePtr, n, 1.0, dold, dnew, X);
 }
 
 /*--------------------------------------------------------------------------*/
@@ -75,8 +77,9 @@ ADOLC_API inline int forode(short tag, int n, int dold, int dnew, double **X) {
 /*        previous order defaults to 0                                      */
 /*                                                                          */
 /* forode(tag, n, tau, dnew, X[n][d+1])                                     */
-ADOLC_API inline int forode(short tag, int n, double tau, int deg, double **X) {
-  return forodec(tag, n, tau, 0, deg, X);
+ADOLC_API inline int forode(ValueTape &tapePtr, int n, double tau, int deg,
+                            double **X) {
+  return forodec(tapePtr, n, tau, 0, deg, X);
 }
 
 /*--------------------------------------------------------------------------*/
@@ -84,8 +87,8 @@ ADOLC_API inline int forode(short tag, int n, double tau, int deg, double **X) {
 /*        both tau and dold default                                         */
 /*                                                                          */
 /* forode(tag, n, dnew, X[n][d+1])                                          */
-ADOLC_API inline int forode(short tag, int n, int deg, double **X) {
-  return forode(tag, n, 1.0, 0, deg, X);
+ADOLC_API inline int forode(ValueTape &tapePtr, int n, int deg, double **X) {
+  return forode(tapePtr, n, 1.0, 0, deg, X);
 }
 
 /*--------------------------------------------------------------------------*/

--- a/ADOL-C/include/adolc/drivers/psdrivers.h
+++ b/ADOL-C/include/adolc/drivers/psdrivers.h
@@ -13,6 +13,7 @@
  recipient's acceptance of the terms of the accompanying license file.
 
 ----------------------------------------------------------------------------*/
+#include "adolc/valuetape/valuetape.h"
 #if !defined(ADOLC_DRIVERS_PSDRIVERS_H)
 #define ADOLC_DRIVERS_PSDRIVERS_H 1
 
@@ -34,7 +35,7 @@ ADOLC_API fint directional_active_gradient_(fint, fint, double *, double *,
 /*                                              directional_active_gradient */
 /*                                                                          */
 ADOLC_API int
-directional_active_gradient(short tag,       /* trace identifier */
+directional_active_gradient(ValueTape &tape, /* trace identifier */
                             int n,           /* number of independents */
                             const double *x, /* value of independents */
                             const double *d, /* direction */
@@ -45,9 +46,9 @@ directional_active_gradient(short tag,       /* trace identifier */
 /*--------------------------------------------------------------------------*/
 /*                                                               abs_normal */
 /*                                                                          */
-ADOLC_API fint abs_normal_(fint *, fint *, fint *, fint *, fdouble *, fdouble *,
+ADOLC_API fint abs_normal_(ValueTape &, fint *, fint *, fint *, fdouble *,
                            fdouble *, fdouble *, fdouble *, fdouble *,
-                           fdouble *, fdouble *, fdouble *);
+                           fdouble *, fdouble *, fdouble *, fdouble *);
 
 /**
  * @brief Compute the ABS-normal form of a taped function.
@@ -92,9 +93,10 @@ ADOLC_API fint abs_normal_(fint *, fint *, fint *, fint *, fdouble *, fdouble *,
  *
  * @return Zero on success, nonzero on failure.
  */
-ADOLC_API int abs_normal(short tag, int m, int n, int swchk, const double *x,
-                         double *y, double *z, double *cz, double *cy,
-                         double **Y, double **J, double **Z, double **L);
+ADOLC_API int abs_normal(ValueTape &tape, int m, int n, int swchk,
+                         const double *x, double *y, double *z, double *cz,
+                         double *cy, double **Y, double **J, double **Z,
+                         double **L);
 
 END_C_DECLS
 

--- a/ADOL-C/include/adolc/drivers/taylor.h
+++ b/ADOL-C/include/adolc/drivers/taylor.h
@@ -12,6 +12,7 @@
  recipient's acceptance of the terms of the accompanying license file.
 
 ----------------------------------------------------------------------------*/
+
 #if !defined(ADOLC_DRIVERS_TAYLOR_H)
 #define ADOLC_DRIVERS_TAYLOR_H 1
 
@@ -19,25 +20,25 @@
 #include <adolc/internal/common.h>
 
 BEGIN_C_DECLS
-
+class ValueTape;
 /****************************************************************************/
 /*                                                       TENSOR EVALUATIONS */
 
 /*--------------------------------------------------------------------------*/
 /* tensor_eval(tag,m,n,d,p,x[n],tensor[m][dim],S[n][p])
       with dim = ((p+d) over d) */
-ADOLC_API int tensor_eval(short tag, int m, int n, int d, int p, double *x,
-                          double **tensor, double **S);
+ADOLC_API int tensor_eval(ValueTape &tape, int m, int n, int d, int p,
+                          double *x, double **tensor, double **S);
 
 /*--------------------------------------------------------------------------*/
 /* inverse_tensor_eval(tag,n,d,p,x,tensor[n][dim],S[n][p])
       with dim = ((p+d) over d) */
-ADOLC_API int inverse_tensor_eval(short tag, int n, int d, int p, double *x,
-                                  double **tensor, double **S);
+ADOLC_API int inverse_tensor_eval(ValueTape &tape, int n, int d, int p,
+                                  double *x, double **tensor, double **S);
 
 /*--------------------------------------------------------------------------*/
 /*  inverse_Taylor_prop(tag,n,d,Y[n][d+1],X[n][d+1]) */
-ADOLC_API int inverse_Taylor_prop(short tag, int n, int d, double **Y,
+ADOLC_API int inverse_Taylor_prop(ValueTape &tape, int n, int d, double **Y,
                                   double **X);
 
 /****************************************************************************/
@@ -70,7 +71,7 @@ ADOLC_API long binomi(size_t n, size_t k);
 
 /*--------------------------------------------------------------------------*/
 /* jac_solv(tag,n,x,b,mode) */
-ADOLC_API int jac_solv(unsigned short tag, int n, const double *x, double *b,
+ADOLC_API int jac_solv(ValueTape &tape, int n, const double *x, double *b,
                        unsigned short mode);
 
 END_C_DECLS

--- a/ADOL-C/include/adolc/edfclasses.h
+++ b/ADOL-C/include/adolc/edfclasses.h
@@ -29,20 +29,20 @@ protected:
 public:
   EDFobject() { init_edf(this); }
   virtual ~EDFobject() { edf_zero(edf); }
-  virtual int function(short tapeId, size_t dim_x, double *x, size_t dim_y,
+  virtual int function(ValueTape &tape, size_t dim_x, double *x, size_t dim_y,
                        double *y) = 0;
-  virtual int zos_forward(short tapeId, size_t dim_x, double *x, size_t dim_y,
-                          double *y) = 0;
-  virtual int fos_forward(short tapeId, size_t dim_x, double *dp_x,
+  virtual int zos_forward(ValueTape &tape, size_t dim_x, double *x,
+                          size_t dim_y, double *y) = 0;
+  virtual int fos_forward(ValueTape &tape, size_t dim_x, double *dp_x,
                           double *dp_X, size_t dim_y, double *dp_y,
                           double *dp_Y) = 0;
-  virtual int fov_forward(short tapeId, size_t dim_x, double *dp_x,
+  virtual int fov_forward(ValueTape &tape, size_t dim_x, double *dp_x,
                           size_t num_dirs, double **dpp_X, size_t dim_y,
                           double *dp_y, double **dpp_Y) = 0;
-  virtual int fos_reverse(short tapeId, size_t dim_y, double *dp_U,
+  virtual int fos_reverse(ValueTape &tape, size_t dim_y, double *dp_U,
                           size_t dim_x, double *dp_Z, double *dp_x,
                           double *dp_y) = 0;
-  virtual int fov_reverse(short tapeId, size_t dim_y, size_t num_weights,
+  virtual int fov_reverse(ValueTape &tape, size_t dim_y, size_t num_weights,
                           double **dpp_U, size_t dim_x, double **dpp_Z,
                           double *dp_x, double *dp_y) = 0;
   int call(size_t dim_x, adouble *xa, size_t dim_y, adouble *ya) {
@@ -61,21 +61,21 @@ protected:
 public:
   EDFobject_iArr() { init_edf(this); }
   virtual ~EDFobject_iArr() { edf_zero(edf); }
-  virtual int function(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int function(ValueTape &tape, size_t iArrLength, size_t *iArr,
                        size_t dim_x, double *x, size_t dim_y, double *y) = 0;
-  virtual int zos_forward(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int zos_forward(ValueTape &tape, size_t iArrLength, size_t *iArr,
                           size_t dim_x, double *x, size_t dim_y, double *y) = 0;
-  virtual int fos_forward(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int fos_forward(ValueTape &tape, size_t iArrLength, size_t *iArr,
                           size_t dim_x, double *dp_x, double *dp_X,
                           size_t dim_y, double *dp_y, double *dp_Y) = 0;
-  virtual int fov_forward(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int fov_forward(ValueTape &tape, size_t iArrLength, size_t *iArr,
                           size_t dim_x, double *dp_x, size_t num_dirs,
                           double **dpp_X, size_t dim_y, double *dp_y,
                           double **dpp_Y) = 0;
-  virtual int fos_reverse(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int fos_reverse(ValueTape &tape, size_t iArrLength, size_t *iArr,
                           size_t dim_y, double *dp_U, size_t dim_x,
                           double *dp_Z, double *dp_x, double *dp_y) = 0;
-  virtual int fov_reverse(short tapeId, size_t iArrLength, size_t *iArr,
+  virtual int fov_reverse(ValueTape &tape, size_t iArrLength, size_t *iArr,
                           size_t dim_y, size_t num_weights, double **dpp_U,
                           size_t dim_x, double **dpp_Z, double *dp_x,
                           double *dp_y) = 0;
@@ -98,26 +98,26 @@ protected:
 public:
   EDFobject_v2() { init_edf(this); }
   virtual ~EDFobject_v2() { edf_zero(edf); }
-  virtual int function(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int function(ValueTape &tape, size_t iArrLen, size_t *iArr,
                        size_t dim_in, size_t dim_out, size_t *insz, double **x,
                        size_t *outsz, double **y, void *ctx) = 0;
-  virtual int zos_forward(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int zos_forward(ValueTape &tape, size_t iArrLen, size_t *iArr,
                           size_t dim_in, size_t dim_out, size_t *insz,
                           double **x, size_t *outsz, double **y, void *ctx) = 0;
-  virtual int fos_forward(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int fos_forward(ValueTape &tape, size_t iArrLen, size_t *iArr,
                           size_t dim_in, size_t dim_out, size_t *insz,
                           double **x, double **xp, size_t *outsz, double **y,
                           double **yp, void *ctx) = 0;
-  virtual int fov_forward(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int fov_forward(ValueTape &tape, size_t iArrLen, size_t *iArr,
                           size_t dim_in, size_t dim_out, size_t *insz,
                           double **x, size_t num_dirs, double ***Xp,
                           size_t *outsz, double **y, double ***Yp,
                           void *ctx) = 0;
-  virtual int fos_reverse(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int fos_reverse(ValueTape &tape, size_t iArrLen, size_t *iArr,
                           size_t dim_out, size_t dim_in, size_t *outsz,
                           double **up, size_t *insz, double **zp, double **x,
                           double **y, void *ctx) = 0;
-  virtual int fov_reverse(short tapeId, size_t iArrLen, size_t *iArr,
+  virtual int fov_reverse(ValueTape &tape, size_t iArrLen, size_t *iArr,
                           size_t dim_out, size_t dim_in, size_t *outsz,
                           size_t num_weights, double ***Up, size_t *insz,
                           double ***Zp, double **x, double **y, void *ctx) = 0;

--- a/ADOL-C/include/adolc/externfcts.h
+++ b/ADOL-C/include/adolc/externfcts.h
@@ -20,35 +20,37 @@
 #include <adolc/internal/common.h>
 
 class adouble;
+class ValueTape;
 
-using ADOLC_ext_fct = int(short tapeId, size_t dim_x, double *x, size_t dim_y,
-                          double *y);
-using ADOLC_ext_fct_fos_forward = int(short tapeId, size_t n, double *dp_x,
+using ADOLC_ext_fct = int(ValueTape &tape, size_t dim_x, double *x,
+                          size_t dim_y, double *y);
+using ADOLC_ext_fct_fos_forward = int(ValueTape &tape, size_t n, double *dp_x,
                                       double *dp_X, size_t m, double *dp_y,
                                       double *dp_Y);
-using ADOLC_ext_fct_fov_forward = int(short tapeId, size_t n, double *dp_x,
+using ADOLC_ext_fct_fov_forward = int(ValueTape &tape, size_t n, double *dp_x,
                                       size_t p, double **dpp_X, size_t m,
                                       double *dp_y, double **dpp_Y);
-using ADOLC_ext_fct_hos_forward = int(short tapeId, size_t n, double *dp_x,
+using ADOLC_ext_fct_hos_forward = int(ValueTape &tape, size_t n, double *dp_x,
                                       size_t d, double **dpp_X, size_t m,
                                       double *dp_y, double **dpp_Y);
-using ADOLC_ext_fct_hov_forward = int(short tapeId, size_t n, double *dp_x,
+using ADOLC_ext_fct_hov_forward = int(ValueTape &tape, size_t n, double *dp_x,
                                       size_t d, size_t p, double ***dppp_X,
                                       size_t m, double *dp_y, double ***dppp_Y);
-using ADOLC_ext_fct_fos_reverse = int(short tapeId, size_t m, double *dp_U,
+using ADOLC_ext_fct_fos_reverse = int(ValueTape &tape, size_t m, double *dp_U,
                                       size_t n, double *dp_Z, double *dp_x,
                                       double *dp_y);
-using ADOLC_ext_fct_fov_reverse = int(short tapeId, size_t m, size_t p,
+using ADOLC_ext_fct_fov_reverse = int(ValueTape &tape, size_t m, size_t p,
                                       double **dpp_U, size_t n, double **dpp_Z,
                                       double *dp_x, double *dp_y);
-using ADOLC_ext_fct_hos_reverse = int(short tapeId, size_t m, double *dp_U,
+using ADOLC_ext_fct_hos_reverse = int(ValueTape &tape, size_t m, double *dp_U,
                                       size_t n, size_t d, double **dpp_Z);
 // dpp_x: {x_{0,0}, x{0,1}, ..., x_{0,keep}}, {x1,0, ..., x_1,keep}, ...} ; n
 // Taylor polynomials of degree keep (i.e., array of size n * (keep+1))
-using ADOLC_ext_fct_hos_ti_reverse = int(short tapeId, size_t m, double **dp_U,
-                                         size_t n, size_t d, double **dpp_Z,
-                                         double **dpp_x, double **dpp_y);
-using ADOLC_ext_fct_hov_reverse = int(short tapeId, size_t m, size_t p,
+using ADOLC_ext_fct_hos_ti_reverse = int(ValueTape &tape, size_t m,
+                                         double **dp_U, size_t n, size_t d,
+                                         double **dpp_Z, double **dpp_x,
+                                         double **dpp_y);
+using ADOLC_ext_fct_hov_reverse = int(ValueTape &tape, size_t m, size_t p,
                                       double **dpp_U, size_t n, size_t d,
                                       double ***dppp_Z, short **spp_nz);
 
@@ -62,38 +64,38 @@ using ADOLC_ext_fct_hov_reverse = int(short tapeId, size_t m, size_t p,
  * separate stack to contain the extra data but this would break the
  * self-containment of the tape.
  */
-using ADOLC_ext_fct_iArr = int(short tapeId, size_t iArrLength, size_t *iArr,
+using ADOLC_ext_fct_iArr = int(ValueTape &tape, size_t iArrLength, size_t *iArr,
                                size_t n, double *x, size_t m, double *y);
-using ADOLC_ext_fct_iArr_fos_forward = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_fos_forward = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t n, double *dp_x,
                                            double *dp_X, size_t m, double *dp_y,
                                            double *dp_Y);
-using ADOLC_ext_fct_iArr_fov_forward = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_fov_forward = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t n, double *dp_x,
                                            size_t p, double **dpp_X, size_t m,
                                            double *dp_y, double **dpp_Y);
-using ADOLC_ext_fct_iArr_hos_forward = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_hos_forward = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t n, double *dp_x,
                                            size_t d, double **dpp_X, size_t m,
                                            double *dp_y, double **dpp_Y);
-using ADOLC_ext_fct_iArr_hov_forward = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_hov_forward = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t n, double *dp_x,
                                            size_t d, size_t p, double ***dppp_X,
                                            size_t m, double *dp_y,
                                            double ***dppp_Y);
-using ADOLC_ext_fct_iArr_fos_reverse = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_fos_reverse = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t m, double *dp_U,
                                            size_t n, double *dp_Z, double *dp_x,
                                            double *dp_y);
-using ADOLC_ext_fct_iArr_fov_reverse = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_fov_reverse = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t m, size_t p,
                                            double **dpp_U, size_t n,
                                            double **dpp_Z, double *dp_x,
                                            double *dp_y);
-using ADOLC_ext_fct_iArr_hos_reverse = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_hos_reverse = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t m, double *dp_U,
                                            size_t n, size_t d, double **dpp_Z);
-using ADOLC_ext_fct_iArr_hov_reverse = int(short tapeId, size_t iArrLength,
+using ADOLC_ext_fct_iArr_hov_reverse = int(ValueTape &tape, size_t iArrLength,
                                            size_t *iArr, size_t m, size_t p,
                                            double **dpp_U, size_t n, size_t d,
                                            double ***dppp_Z, short **spp_nz);
@@ -105,12 +107,11 @@ using ADOLC_ext_fct_iArr_hov_reverse = int(short tapeId, size_t iArrLength,
  * instead.
  */
 struct ADOLC_API ext_diff_fct {
-  // This is the id of the outer tape that calls the external differentiated
-  // function later
-  short tapeId{0};
+  // outer tape that calls the external differentiated function later
+  ValueTape *outerTapePtr{nullptr};
 
   // tape that stores the external differentiated function.
-  short ext_tape_id{0};
+  ValueTape *innerTapePtr{nullptr};
   /**
    * DO NOT touch - the function pointer is set through reg_ext_fct
    */
@@ -335,12 +336,12 @@ struct ADOLC_API ext_diff_fct {
 /****************************************************************************/
 /*                                                          This is all C++ */
 
-ADOLC_API ext_diff_fct *reg_ext_fct(short tapeId, short ext_tape_id,
+ADOLC_API ext_diff_fct *reg_ext_fct(ValueTape &outerTape, ValueTape &innerTape,
                                     ADOLC_ext_fct ext_fct);
-ADOLC_API ext_diff_fct *reg_ext_fct(short tapeId, short ext_tape_id,
+ADOLC_API ext_diff_fct *reg_ext_fct(ValueTape &outerTape, ValueTape &innerTape,
                                     ADOLC_ext_fct_iArr ext_fct);
 
-ADOLC_API ext_diff_fct *get_ext_diff_fct(short tapeId, size_t index);
+ADOLC_API ext_diff_fct *get_ext_diff_fct(ValueTape &tape, size_t index);
 
 ADOLC_API int call_ext_fct(ext_diff_fct *edfct, size_t dim_x, adouble *xa,
                            size_t dim_y, adouble *ya);

--- a/ADOL-C/include/adolc/externfcts2.h
+++ b/ADOL-C/include/adolc/externfcts2.h
@@ -18,26 +18,27 @@
 
 #include <adolc/adolcexport.h>
 #include <adolc/internal/common.h>
+class ValueTape;
 
-using ADOLC_ext_fct_v2 = int(short tapeId, size_t iArrLen, size_t *iArr,
+using ADOLC_ext_fct_v2 = int(ValueTape &tape, size_t iArrLen, size_t *iArr,
                              size_t nin, size_t nout, size_t *insz, double **x,
                              size_t *outsz, double **y, void *ctx);
-using ADOLC_ext_fct_v2_fos_forward = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_fos_forward = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nin, size_t nout,
                                          size_t *insz, double **x, double **xp,
                                          size_t *outsz, double **y, double **yp,
                                          void *ctx);
-using ADOLC_ext_fct_v2_fov_forward = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_fov_forward = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nin, size_t nout,
                                          size_t *insz, double **x, size_t ndir,
                                          double ***Xp, size_t *outsz,
                                          double **y, double ***Yp, void *ctx);
-using ADOLC_ext_fct_v2_fos_reverse = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_fos_reverse = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nout, size_t nin,
                                          size_t *outsz, double **up,
                                          size_t *insz, double **zp, double **x,
                                          double **y, void *ctx);
-using ADOLC_ext_fct_v2_fov_reverse = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_fov_reverse = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nout, size_t nin,
                                          size_t *outsz, size_t dir,
                                          double ***Up, size_t *insz,
@@ -45,13 +46,13 @@ using ADOLC_ext_fct_v2_fov_reverse = int(short tapeId, size_t iArrLen,
                                          void *ctx);
 
 /* The following two aren't implemented */
-using ADOLC_ext_fct_v2_hos_forward = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_hos_forward = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nin, size_t nout,
                                          size_t *insz, double **x,
                                          size_t degree, double ***Xp,
                                          size_t *outsz, double **y,
                                          double ***Yp, void *ctx);
-using ADOLC_ext_fct_v2_hov_forward = int(short tapeId, size_t iArrLen,
+using ADOLC_ext_fct_v2_hov_forward = int(ValueTape &tape, size_t iArrLen,
                                          size_t *iArr, size_t nin, size_t nout,
                                          size_t *insz, double **x,
                                          size_t degree, size_t ndir,
@@ -61,10 +62,10 @@ using ADOLC_ext_fct_v2_hov_forward = int(short tapeId, size_t iArrLen,
 struct ADOLC_API ext_diff_fct_v2 {
   // This is the id of the outer tape that calls the external differentiated
   // function later
-  short tapeId{0};
+  ValueTape *outerTapePtr{nullptr};
 
   // tape that stores the external differentiated function.
-  short ext_tape_id{0};
+  ValueTape *innerTapePtr{nullptr};
   /**
    * DO NOT touch - the function pointer is set through reg_ext_fct
    */
@@ -226,9 +227,10 @@ struct ADOLC_API ext_diff_fct_v2 {
   char user_allocated_mem;
 };
 
-ADOLC_API ext_diff_fct_v2 *reg_ext_fct(short tapeId, short ext_tape_id,
+ADOLC_API ext_diff_fct_v2 *reg_ext_fct(ValueTape &outerTape,
+                                       ValueTape &innerTape,
                                        ADOLC_ext_fct_v2 ext_fct);
-ADOLC_API ext_diff_fct_v2 *get_ext_diff_fct_v2(short tapeId, size_t index);
+ADOLC_API ext_diff_fct_v2 *get_ext_diff_fct_v2(ValueTape &tape, size_t index);
 ADOLC_API int call_ext_fct(ext_diff_fct_v2 *edfct, size_t iArrLen, size_t *iArr,
                            size_t nin, size_t out, size_t *insz, adouble **x,
                            size_t *outsz, adouble **y);
@@ -239,5 +241,4 @@ ADOLC_API inline void edf_set_opaque_context(ext_diff_fct_v2 *edfct,
                                              void *ctx) {
   edfct->context = ctx;
 }
-
 #endif

--- a/ADOL-C/include/adolc/fixpoint.h
+++ b/ADOL-C/include/adolc/fixpoint.h
@@ -23,8 +23,9 @@ typedef int (*double_F)(double *, double *, double *, size_t, size_t);
 typedef int (*adouble_F)(adouble *, adouble *, adouble *, size_t, size_t);
 typedef double (*norm_F)(double *, size_t);
 typedef double (*norm_deriv_F)(double *, size_t);
-
-ADOLC_API int fp_iteration(short tapeId, short sub_tape_num, double_F,
+class ValueTape;
+void fpi_stack_clear();
+ADOLC_API int fp_iteration(ValueTape &outerTape, ValueTape &innerTape, double_F,
                            adouble_F, norm_F, norm_deriv_F, double epsilon,
                            double epsilon_deriv, size_t N_max,
                            size_t N_max_deriv, adouble *x_0, adouble *u,

--- a/ADOL-C/include/adolc/interfaces.h
+++ b/ADOL-C/include/adolc/interfaces.h
@@ -43,6 +43,7 @@
  recipient's acceptance of the terms of the accompanying license file.
 
 ----------------------------------------------------------------------------*/
+#include "adolc/valuetape/valuetape.h"
 #if !defined(ADOLC_INTERFACES_H)
 #define ADOLC_INTERFACES_H 1
 
@@ -58,7 +59,7 @@
 /****************************************************************************/
 /*                                                       Now the C++ THINGS */
 #if defined(__cplusplus)
-
+class ValueTape;
 /****************************************************************************/
 /*                                           FORWARD MODE, overloaded calls */
 
@@ -66,38 +67,39 @@
 /*    General scalar call. For d=0 or d=1 done by specialized code          */
 /*                                                                          */
 /* forward(tag, m, n, d, keep, X[n][d+1], Y[m][d+1]) : hos || fos || zos    */
-ADOLC_API int forward(short, int, int, int, int, double **, double **);
+ADOLC_API int forward(ValueTape &, int, int, int, int, double **, double **);
 
 /*--------------------------------------------------------------------------*/
 /*    Y can be one dimensional if m=1. d=0 or d=1 done by specialized code  */
 /*                                                                          */
 /* forward(tag, m, n, d, keep, X[n][d+1], Y[d+1]) : hos || fos || zos       */
-ADOLC_API int forward(short, int, int, int, int, double **, double *);
+ADOLC_API int forward(ValueTape &, int, int, int, int, double **, double *);
 
 /*--------------------------------------------------------------------------*/
 /*    X and Y can be one dimensional if d = 0; done by specialized code     */
 /*                                                                          */
 /* forward(tag, m, n, d, keep, X[n], Y[m]) : zos                            */
-ADOLC_API int forward(short, int, int, int, int, const double *, double *);
+ADOLC_API int forward(ValueTape &, int, int, int, int, const double *,
+                      double *);
 
 /*--------------------------------------------------------------------------*/
 /*    X and Y can be one dimensional if d omitted; done by specialized code */
 /*                                                                          */
 /* forward(tag, m, n, keep, X[n], Y[m]) : zos                               */
-ADOLC_API int forward(short, int, int, int, const double *, double *);
+ADOLC_API int forward(ValueTape &, int, int, int, const double *, double *);
 
 /*--------------------------------------------------------------------------*/
 /*  General vector call                                                     */
 /*                                                                          */
 /* forward(tag, m, n, d, p, x[n], X[n][p][d], y[m], Y[m][p][d]) : hov       */
-ADOLC_API int forward(short, int, int, int, int, const double *,
+ADOLC_API int forward(ValueTape &, int, int, int, int, const double *,
                       const double *const *const *, double *, double ***);
 
 /*--------------------------------------------------------------------------*/
 /*  d = 1 may be omitted. General vector call, done by specialized code     */
 /*                                                                          */
 /* forward(tag, m, n, p, x[n], X[n][p], y[m], Y[m][p]) : fov                */
-ADOLC_API int forward(short, int, int, int, const double *,
+ADOLC_API int forward(ValueTape &, int, int, int, const double *,
                       const double *const *, double *, double **);
 
 /****************************************************************************/
@@ -107,38 +109,38 @@ ADOLC_API int forward(short, int, int, int, const double *,
 /*  General call                                                            */
 /*                                                                          */
 /* reverse(tag, m, n, d, u[m], Z[n][d+1]) : hos                             */
-ADOLC_API int reverse(short, int, int, int, const double *, double **);
+ADOLC_API int reverse(ValueTape &, int, int, int, const double *, double **);
 
 /*--------------------------------------------------------------------------*/
 /*    u can be a scalar if m=1                                              */
 /*                                                                          */
 /* reverse(tag, m, n, d, u, Z[n][d+1]) : hos                                */
-ADOLC_API int reverse(short, int, int, int, double, double **);
+ADOLC_API int reverse(ValueTape &, int, int, int, double, double **);
 
 /*--------------------------------------------------------------------------*/
 /*    Z can be vector if d = 0; done by specialized code                    */
 /*                                                                          */
 /* reverse(tag, m, n, d, u[m], Z[n]) : fos                                  */
-ADOLC_API int reverse(short, int, int, int, const double *, double *);
+ADOLC_API int reverse(ValueTape &, int, int, int, const double *, double *);
 
 /*--------------------------------------------------------------------------*/
 /*    u can be a scalar if m=1 and d=0; done by specialized code            */
 /*                                                                          */
 /* reverse(tag, m, n, d, u, Z[n]) : fos                                     */
-ADOLC_API int reverse(short, int, int, int, double, double *);
+ADOLC_API int reverse(ValueTape &, int, int, int, double, double *);
 
 /*--------------------------------------------------------------------------*/
 /*  General vector call                                                     */
 /*                                                                          */
 /* reverse(tag, m, n, d, q, U[q][m], Z[q][n][d+1], nz[q][n]) : hov          */
-ADOLC_API int reverse(short, int, int, int, int, const double *const *,
+ADOLC_API int reverse(ValueTape &, int, int, int, int, const double *const *,
                       double ***, short ** = nullptr);
 
 /*--------------------------------------------------------------------------*/
 /*    U can be a vector if m=1                                              */
 /*                                                                          */
 /* reverse(tag, m, n, d, q, U[q], Z[q][n][d+1], nz[q][n]) : hov             */
-ADOLC_API int reverse(short, int, int, int, int, double *, double ***,
+ADOLC_API int reverse(ValueTape &, int, int, int, int, double *, double ***,
                       short ** = nullptr);
 
 /*--------------------------------------------------------------------------*/
@@ -146,7 +148,7 @@ ADOLC_API int reverse(short, int, int, int, int, double *, double ***,
 /*    If d=0 then Z may be a matrix, no nz; done by specialized code        */
 /*                                                                          */
 /* reverse(tag, m, n, d, q, U[q][m], Z[q][n]) : fov                         */
-ADOLC_API int reverse(short, int, int, int, int, const double *const *,
+ADOLC_API int reverse(ValueTape &, int, int, int, int, const double *const *,
                       double **);
 
 /*--------------------------------------------------------------------------*/
@@ -154,7 +156,8 @@ ADOLC_API int reverse(short, int, int, int, int, const double *const *,
 /*    d=0 may be omitted, Z is a matrix, no nz; done by specialized code    */
 /*                                                                          */
 /* reverse(tag, m, n, q, U[q][m], Z[q][n]) : fov                            */
-ADOLC_API int reverse(short, int, int, int, const double *const *, double **);
+ADOLC_API int reverse(ValueTape &, int, int, int, const double *const *,
+                      double **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
@@ -162,14 +165,14 @@ ADOLC_API int reverse(short, int, int, int, const double *const *, double **);
 /*    Done by specialized code                                              */
 /*                                                                          */
 /* reverse(tag, m, n, d, q, U[q], Z[q][n]) : fov                            */
-ADOLC_API int reverse(short, int, int, int, int, double *, double **);
+ADOLC_API int reverse(ValueTape &, int, int, int, int, double *, double **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /*    If q and U are omitted they default to m and I so that as above       */
 /*                                                                          */
 /* reverse(tag, m, n, d, Z[q][n][d+1], nz[q][n]) : hov                      */
-ADOLC_API int reverse(short, int, int, int, double ***, short ** = 0);
+ADOLC_API int reverse(ValueTape &, int, int, int, double ***, short ** = 0);
 
 #endif
 
@@ -185,54 +188,54 @@ BEGIN_C_DECLS
 /*                                                                      ZOS */
 /* zos_forward(tag, m, n, keep, x[n], y[m])                                 */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int zos_forward(short, int, int, int, const double *, double *);
+ADOLC_API int zos_forward(ValueTape &, int, int, int, const double *, double *);
 
 /* zos_forward_nk(tag, m, n, x[n], y[m])                                    */
 /* (no keep, defined in uni5_for.cpp, but not supported in ADOL-C 1.8)        */
-ADOLC_API int zos_forward_nk(short, int, int, const double *, double *);
+ADOLC_API int zos_forward_nk(ValueTape &, int, int, const double *, double *);
 
 /* zos_forward_partx(tag, m, n, ndim[n], x[n][d], y[m])                     */
 /* (based on zos_forward)                                                   */
 
-ADOLC_API int zos_forward_partx(short, int, int, const int *,
+ADOLC_API int zos_forward_partx(ValueTape &, int, int, const int *,
                                 const double *const *, double *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                      FOS */
 /* fos_forward(tag, m, n, keep, x[n], X[n], y[m], Y[m])                     */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int fos_forward(short, int, int, int, const double *, const double *,
-                          double *, double *);
+ADOLC_API int fos_forward(ValueTape &, int, int, int, const double *,
+                          const double *, double *, double *);
 
 /* fos_forward_nk(tag,m,n,x[n],X[n],y[m],Y[m])                              */
 /* (no keep, defined in uni5_for.cpp, but not supported in ADOL-C 1.8)        */
-ADOLC_API int fos_forward_nk(short, int, int, const double *, const double *,
-                             double *, double *);
+ADOLC_API int fos_forward_nk(ValueTape &, int, int, const double *,
+                             const double *, double *, double *);
 
 /* fos_forward_partx(tag, m, n, ndim[n], x[n][][2], y[m][2])                */
 /* (based on fos_forward)                                                   */
-ADOLC_API int fos_forward_partx(short, int, int, const int *,
+ADOLC_API int fos_forward_partx(ValueTape &, int, int, const int *,
                                 const double *const *const *, double **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                      HOS */
 /* hos_forward(tag, m, n, d, keep, x[n], X[n][d], y[m], Y[m][d])            */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int hos_forward(short, int, int, int, int, const double *,
+ADOLC_API int hos_forward(ValueTape &, int, int, int, int, const double *,
                           const double *const *, double *, double **);
 
 /* hos_forward_nk(tag, m, n, d, x[n], X[n][d], y[m], Y[m][d])               */
 /* (no keep, defined in uni5_for.cpp, but not supported in ADOL-C 1.8)        */
-ADOLC_API int hos_forward_nk(short, int, int, int, const double *,
+ADOLC_API int hos_forward_nk(ValueTape &, int, int, int, const double *,
                              const double *const *, double *, double **);
 
 /* hos_forward_partx(tag, m, n, ndim[n], d, X[n][d+1], Y[m][d+1])           */
 /* (defined in forward_partx.cpp)                                             */
-ADOLC_API int hos_forward_partx(short, int, int, const int *, int,
+ADOLC_API int hos_forward_partx(ValueTape &, int, int, const int *, int,
                                 const double *const *const *, double **);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint hos_forward_(const fint *, const fint *, const fint *,
+ADOLC_API fint hos_forward_(ValueTape &, const fint *, const fint *,
                             const fint *, const fint *, const fdouble *,
                             const fdouble *, fdouble *, fdouble *);
 
@@ -240,19 +243,20 @@ ADOLC_API fint hos_forward_(const fint *, const fint *, const fint *,
 /*                                                                      FOV */
 /* fov_forward(tag, m, n, p, x[n], X[n][p], y[m], Y[m][p])                  */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int fov_forward(short, int, int, int, const double *,
+ADOLC_API int fov_forward(ValueTape &, int, int, int, const double *,
                           const double *const *, double *, double **);
-ADOLC_API int fov_offset_forward(short, int, int, int, int, const double *,
-                                 const double *const *, double *, double **);
+ADOLC_API int fov_offset_forward(ValueTape &, int, int, int, int,
+                                 const double *, const double *const *,
+                                 double *, double **);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint fov_forward_(const fint *, const fint *, const fint *,
+ADOLC_API fint fov_forward_(ValueTape &, const fint *, const fint *,
                             const fint *, const fdouble *, const fdouble *,
                             fdouble *, fdouble *);
 
 /*  fov_forward_partx(tag, m, n, ndim[n], p,                                */
 /*                    x[n][], X[n][][p],y[m], Y[m][p])                      */
-ADOLC_API int fov_forward_partx(short, int, int, const int *, int,
+ADOLC_API int fov_forward_partx(ValueTape &, int, int, const int *, int,
                                 const double *const *,
                                 const double *const *const *, double *,
                                 double **);
@@ -261,17 +265,17 @@ ADOLC_API int fov_forward_partx(short, int, int, const int *, int,
 /*                                                                      HOV */
 /* hov_forward(tag, m, n, d, p, x[n], X[n][p][d], y[m], Y[m][p][d])         */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int hov_forward(short, int, int, int, int, const double *,
+ADOLC_API int hov_forward(ValueTape &, int, int, int, int, const double *,
                           const double *const *const *, double *, double ***);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint hov_forward_(const fint *, const fint *, const fint *,
+ADOLC_API fint hov_forward_(ValueTape &, const fint *, const fint *,
                             const fint *, const fint *, const fdouble *,
                             const fdouble *, fdouble *, fdouble *);
 
 /*  hov_forward_partx(tag, m, n, ndim[n], d, p,                             */
 /*                    x[n][], X[n][][p][d], y[m], Y[m][p][d])               */
-ADOLC_API int hov_forward_partx(short, int, int, const int *, int, int,
+ADOLC_API int hov_forward_partx(ValueTape &, int, int, const int *, int, int,
                                 const double *const *,
                                 const double *const *const *const *, double *,
                                 double ***);
@@ -280,9 +284,9 @@ ADOLC_API int hov_forward_partx(short, int, int, const int *, int, int,
 /*                                                                   HOV_WK */
 /* hov_wk_forward(tag, m, n, d, keep, p, x[n], X[n][p][d], y[m], Y[m][p][d])  */
 /* (defined in uni5_for.cpp)                                                 */
-ADOLC_API int hov_wk_forward(short, int, int, int, int, int, const double *,
-                             const double *const *const *, double *,
-                             double ***);
+ADOLC_API int hov_wk_forward(ValueTape &, int, int, int, int, int,
+                             const double *, const double *const *const *,
+                             double *, double ***);
 
 /* now pack the arrays into vectors for Fortran calling                     */
 ADOLC_API fint hov_wk_forward_(const fint *, const fint *, const fint *,
@@ -295,14 +299,14 @@ ADOLC_API fint hov_wk_forward_(const fint *, const fint *, const fint *,
 /*                                                            INT_FOR, SAFE */
 /* int_forward_safe(tag, m, n, p, X[n][p], Y[m][p])                         */
 
-ADOLC_API int int_forward_safe(short, int, int, int, const size_t *const *,
-                               size_t **);
+ADOLC_API int int_forward_safe(ValueTape &, int, int, int,
+                               const size_t *const *, size_t **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           INT_FOR, TIGHT */
 /* int_forward_tight(tag, m, n, p, x[n], X[n][p], y[m], Y[m][p])            */
 
-ADOLC_API int int_forward_tight(short, int, int, int, const double *,
+ADOLC_API int int_forward_tight(ValueTape &, int, int, int, const double *,
                                 const size_t *const *, double *, size_t **);
 
 /****************************************************************************/
@@ -311,14 +315,14 @@ ADOLC_API int int_forward_tight(short, int, int, int, const double *,
 /*                                                            INDOPRO, SAFE */
 /* indopro_forward_safe(tag, m, n, p, x[n], *Y[m])                          */
 
-ADOLC_API int indopro_forward_safe(short, int, int, const double *,
+ADOLC_API int indopro_forward_safe(ValueTape &, int, int, const double *,
                                    unsigned int **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           INDOPRO, TIGHT */
 /* indopro_forward_tight(tag, m, n,  x[n], *Y[m])                           */
 
-ADOLC_API int indopro_forward_tight(short, int, int, const double *,
+ADOLC_API int indopro_forward_tight(ValueTape &, int, int, const double *,
                                     unsigned int **);
 
 /****************************************************************************/
@@ -327,27 +331,27 @@ ADOLC_API int indopro_forward_tight(short, int, int, const double *,
 /*                                                            INDOPRO, SAFE */
 /* nonl_ind_forward_safe(tag, m, n, p, x[n], *Y[m])                          */
 
-ADOLC_API int nonl_ind_forward_safe(short, int, int, const double *,
+ADOLC_API int nonl_ind_forward_safe(ValueTape &, int, int, const double *,
                                     unsigned int **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           INDOPRO, TIGHT */
 /* nonl_ind_forward_tight(tag, m, n,  x[n], *Y[m])                           */
 
-ADOLC_API int nonl_ind_forward_tight(short, int, int, const double *,
+ADOLC_API int nonl_ind_forward_tight(ValueTape &, int, int, const double *,
                                      unsigned int **);
 /*--------------------------------------------------------------------------*/
 /*                                                            INDOPRO, SAFE */
 /* nonl_ind_old_forward_safe(tag, m, n, p, x[n], *Y[m]) */
 
-ADOLC_API int nonl_ind_old_forward_safe(short, int, int, const double *,
+ADOLC_API int nonl_ind_old_forward_safe(ValueTape &, int, int, const double *,
                                         unsigned int **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                           INDOPRO, TIGHT */
 /* nonl_ind_old_forward_tight(tag, m, n,  x[n], *Y[m]) */
 
-ADOLC_API int nonl_ind_old_forward_tight(short, int, int, const double *,
+ADOLC_API int nonl_ind_old_forward_tight(ValueTape &, int, int, const double *,
                                          unsigned int **);
 
 /****************************************************************************/
@@ -357,39 +361,40 @@ ADOLC_API int nonl_ind_old_forward_tight(short, int, int, const double *,
 /*                                                                      FOS */
 /* fos_reverse(tag, m, n, u[m], z[n])                                       */
 /* (defined in fo_rev.cpp)                                                    */
-ADOLC_API int fos_reverse(short, int, int, const double *, double *);
+ADOLC_API int fos_reverse(ValueTape &, int, int, const double *, double *);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint fos_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint fos_reverse_(ValueTape &, const fint *, const fint *,
                             const fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                      HOS */
 /*  hos_reverse(tag, m, n, d, u[m], Z[n][d+1])                              */
 /* (defined in ho_rev.cpp)                                                    */
-ADOLC_API int hos_reverse(short, int, int, int, const double *, double **);
+ADOLC_API int hos_reverse(ValueTape &, int, int, int, const double *,
+                          double **);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint hos_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint hos_reverse_(ValueTape &, const fint *, const fint *,
                             const fint *, const fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                   HOS_TI */
 /*  hos_ti_reverse(tag, m, n, d, U[m][d+1], Z[n][d+1])                      */
 /* (defined in ho_rev.cpp)                                                    */
-ADOLC_API int hos_ti_reverse(short, int, int, int, const double *const *,
+ADOLC_API int hos_ti_reverse(ValueTape &, int, int, int, const double *const *,
                              double **);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint hos_ti_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint hos_ti_reverse_(ValueTape &, const fint *, const fint *,
                                const fint *, const fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                   HOS_OV */
 /*  hos_ov_reverse(tag, m, n, d, p, U[m][d+1], Z[p][n][d+1])                */
 /* (defined in ho_rev.cpp)                                                    */
-ADOLC_API int hos_ov_reverse(short, int, int, int, int, const double *const *,
-                             double ***);
+ADOLC_API int hos_ov_reverse(ValueTape &, int, int, int, int,
+                             const double *const *, double ***);
 
 /* now pack the arrays into vectors for Fortran calling                     */
 ADOLC_API fint hos_ov_reverse_(const fint *, const fint *, const fint *,
@@ -400,22 +405,22 @@ ADOLC_API fint hos_ov_reverse_(const fint *, const fint *, const fint *,
 /*                                                                      FOV */
 /* fov_reverse(tag, m, n, p, U[p][m], Z[p][n])                              */
 /* (defined in fo_rev.cpp)                                                    */
-ADOLC_API int fov_reverse(short, int, int, int, const double *const *,
+ADOLC_API int fov_reverse(ValueTape &, int, int, int, const double *const *,
                           double **);
 
 /* now pack the arrays into vectors for Fortran calling                     */
-ADOLC_API fint fov_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint fov_reverse_(ValueTape &, const fint *, const fint *,
                             const fint *, const fdouble *, fdouble *);
 
 /*--------------------------------------------------------------------------*/
 /*                                                                      HOV */
 /* hov_reverse(tag, m, n, d, p, U[p][m], Z[p][n][d+1], nz[p][n])            */
 /* (defined in ho_rev.cpp)                                                    */
-ADOLC_API int hov_reverse(short, int, int, int, int, const double *const *,
-                          double ***, short **);
+ADOLC_API int hov_reverse(ValueTape &, int, int, int, int,
+                          const double *const *, double ***, short **);
 
 /* now pack the arrays into vectors for Fortran calling      */
-ADOLC_API fint hov_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint hov_reverse_(ValueTape &, const fint *, const fint *,
                             const fint *, const fint *, const fdouble *,
                             fdouble *);
 
@@ -423,12 +428,12 @@ ADOLC_API fint hov_reverse_(const fint *, const fint *, const fint *,
 /*                                                                   HOV_TI */
 /* hov_ti_reverse(tag, m, n, d, p, U[p][m][d+1], Z[p][n][d+1], nz[p][n])    */
 /* (defined in ho_rev.cpp)                                                   */
-ADOLC_API int hov_ti_reverse(short, int, int, int, int,
+ADOLC_API int hov_ti_reverse(ValueTape &, int, int, int, int,
                              const double *const *const *, double ***,
                              short **);
 
 /* now pack the arrays into vectors for Fortran calling      */
-ADOLC_API fint hov_ti_reverse_(const fint *, const fint *, const fint *,
+ADOLC_API fint hov_ti_reverse_(ValueTape &, const fint *, const fint *,
                                const fint *, const fint *, const fdouble *,
                                fdouble *);
 
@@ -438,41 +443,42 @@ ADOLC_API fint hov_ti_reverse_(const fint *, const fint *, const fint *,
 /*                                                           INT_REV, TIGHT */
 /* int_reverse_tight(tag, m, n, q, U[q][m], Z[q][n])                        */
 
-ADOLC_API int int_reverse_tight(short, int, int, int, const size_t *const *,
-                                size_t **);
+ADOLC_API int int_reverse_tight(ValueTape &, int, int, int,
+                                const size_t *const *, size_t **);
 
 /*--------------------------------------------------------------------------*/
 /*                                                            INT_REV, SAFE */
 /* int_reverse_safe(tag, m, n, q, U[q][m], Z[q][n])                         */
 
-ADOLC_API int int_reverse_safe(short, int, int, int, const size_t *const *,
-                               size_t **);
+ADOLC_API int int_reverse_safe(ValueTape &, int, int, int,
+                               const size_t *const *, size_t **);
 
 /*--------------------------------------------------------------------------*/
-ADOLC_API size_t get_num_switches(short);
-ADOLC_API int zos_pl_forward(short, int, int, int, const double *, double *,
-                             double *);
+ADOLC_API size_t get_num_switches(ValueTape &);
+ADOLC_API int zos_pl_forward(ValueTape &, int, int, int, const double *,
+                             double *, double *);
 ADOLC_API short firstsign(int, const double *, const double *);
 ADOLC_API short ext_firstsign(double, double, int, double *, double *);
 ADOLC_API short ext_firstsign2(double, int, double *, double *);
-ADOLC_API int fos_pl_forward(short, int, int, const double *, const double *,
-                             double *, double *, double *, double *);
-ADOLC_API int fov_pl_forward(short, int, int, int, const double *,
+ADOLC_API int fos_pl_forward(ValueTape &, int, int, const double *,
+                             const double *, double *, double *, double *,
+                             double *);
+ADOLC_API int fov_pl_forward(ValueTape &, int, int, int, const double *,
                              const double *const *, double *, double **,
                              double *, double **, short *);
-ADOLC_API int fos_pl_sig_forward(short, int, int, const double *,
+ADOLC_API int fos_pl_sig_forward(ValueTape &, int, int, const double *,
                                  const double *, int, const short *,
                                  const short *, double *, double *, double *,
                                  double *, short *);
-ADOLC_API int fov_pl_sig_forward(short, int, int, int, const double *,
+ADOLC_API int fov_pl_sig_forward(ValueTape &, int, int, int, const double *,
                                  const double *const *, int, const short *,
                                  const short *, double *, double **, double *,
                                  double **, short *);
-ADOLC_API int indopro_forward_absnormal(short, int, int, int, const double *,
-                                        unsigned int **);
+ADOLC_API int indopro_forward_absnormal(ValueTape &, int, int, int,
+                                        const double *, unsigned int **);
 /*--------------------------------------------------------------------------*/
-ADOLC_API int fos_pl_reverse(short, int, int, int, int, double *);
-ADOLC_API int fos_pl_sig_reverse(short, int, int, int, const short *,
+ADOLC_API int fos_pl_reverse(ValueTape &, int, int, int, int, double *);
+ADOLC_API int fos_pl_sig_reverse(ValueTape &, int, int, int, const short *,
                                  const double *, double *);
 
 END_C_DECLS

--- a/ADOL-C/include/adolc/lie/drivers.h
+++ b/ADOL-C/include/adolc/lie/drivers.h
@@ -20,12 +20,13 @@
 
 /* C++ declarations available only when compiling with C++  */
 #if defined(__cplusplus)
-
-ADOLC_API int lie_scalar(short, short, short, double *, short, double *);
-ADOLC_API int lie_scalar(short, short, short, short, double *, short,
+class ValueTape;
+ADOLC_API int lie_scalar(ValueTape &, short, short, double *, short, double *);
+ADOLC_API int lie_scalar(ValueTape &, short, short, short, double *, short,
                          double **);
-ADOLC_API int lie_gradient(short, short, short, double *, short, double **);
-ADOLC_API int lie_gradient(short, short, short, short, double *, short,
+ADOLC_API int lie_gradient(ValueTape &, short, short, double *, short,
+                           double **);
+ADOLC_API int lie_gradient(ValueTape &, short, short, short, double *, short,
                            double ***);
 
 #endif
@@ -35,14 +36,18 @@ ADOLC_API int lie_gradient(short, short, short, short, double *, short,
 extern "C" {
 #endif
 
-ADOLC_API int lie_scalarc(short, short, short, double *, short, double *);
-ADOLC_API int lie_scalarcv(short, short, short, short, double *, short,
+ADOLC_API int lie_scalarc(ValueTape &, ValueTape &, short, double *, short,
+                          double *);
+ADOLC_API int lie_scalarcv(ValueTape &, ValueTape &, short, short, double *,
+                           short, double **);
+ADOLC_API int lie_gradientc(ValueTape &, ValueTape &, short, double *, short,
+                            double **);
+ADOLC_API int lie_gradientcv(ValueTape &, ValueTape &, short, short, double *,
+                             short, double ***);
+ADOLC_API int lie_covector(ValueTape &, ValueTape &, short, double *, short,
                            double **);
-ADOLC_API int lie_gradientc(short, short, short, double *, short, double **);
-ADOLC_API int lie_gradientcv(short, short, short, short, double *, short,
-                             double ***);
-ADOLC_API int lie_covector(short, short, short, double *, short, double **);
-ADOLC_API int lie_bracket(short, short, short, double *, short, double **);
+ADOLC_API int lie_bracket(ValueTape &, ValueTape &, short, double *, short,
+                          double **);
 
 #if defined(__cplusplus)
 }

--- a/ADOL-C/include/adolc/tapedoc/tapedoc.h
+++ b/ADOL-C/include/adolc/tapedoc/tapedoc.h
@@ -12,7 +12,6 @@
  recipient's acceptance of the terms of the accompanying license file.
 
 ----------------------------------------------------------------------------*/
-
 #if !defined(ADOLC_TAPEDOC_TAPEDOC_H)
 #define ADOLC_TAPEDOC_TAPEDOC_H 1
 
@@ -20,12 +19,12 @@
 #include <adolc/internal/common.h>
 
 BEGIN_C_DECLS
-
+class ValueTape;
 /****************************************************************************/
 /*                                                                 tape_doc */
 /* tape_doc(tag, m, n, x[n], y[m])                                          */
 
-ADOLC_API void tape_doc(short, int, int, const double *, double *);
+ADOLC_API void tape_doc(ValueTape &, int, int, const double *, double *);
 
 /****************************************************************************/
 /*                                                               THAT'S ALL */

--- a/ADOL-C/include/adolc/valuetape/tapeinfos.h
+++ b/ADOL-C/include/adolc/valuetape/tapeinfos.h
@@ -41,13 +41,11 @@ struct TapeInfos {
 
   ~TapeInfos();
   TapeInfos() = default;
-  TapeInfos(short tapeId);
   TapeInfos(const TapeInfos &) = delete;
   TapeInfos &operator=(const TapeInfos &) = delete;
   TapeInfos(TapeInfos &&other) noexcept;
   TapeInfos &operator=(TapeInfos &&other) noexcept;
 
-  short tapeId_{-1};
   int inUse{0};
   size_t numInds{0};
   size_t numDeps{0};

--- a/ADOL-C/include/adolc/valuetape/valuetape.h
+++ b/ADOL-C/include/adolc/valuetape/valuetape.h
@@ -12,7 +12,6 @@
 #include <adolc/valuetape/globaltapevarscl.h>
 #include <adolc/valuetape/persistanttapeinfos.h>
 #include <adolc/valuetape/tapeinfos.h>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <stack>
@@ -82,10 +81,8 @@ class ADOLC_API ValueTape {
 public:
   ~ValueTape();
 
-  // a tape always need a tapeId,
-  ValueTape() = delete;
-  ValueTape(short tapeId)
-      : tapeInfos_(tapeId), perTapeInfos_(tapeId, readConfigFile()),
+  ValueTape()
+      : perTapeInfos_(readConfigFile()),
         ext_buffer_(edf_zero_wrapper<ext_diff_fct>),
         ext2_buffer_(edf_zero_wrapper<ext_diff_fct_v2>),
         cp_buffer_(init_CpInfos) {}
@@ -267,7 +264,7 @@ public:
   size_t numSwitches() const { return tapeInfos_.numSwitches; }
   void increment_numSwitches() { ++tapeInfos_.numSwitches; }
 
-  short tapeId() const { return tapeInfos_.tapeId_; }
+  short tapeId() const { return perTapeInfos_.tapeId_; }
   size_t no_min_max() { return tapeInfos_.stats[TapeInfos::NO_MIN_MAX]; }
   size_t ext_diff_fct_index() const { return tapeInfos_.ext_diff_fct_index; }
   void ext_diff_fct_index(size_t index) {
@@ -693,16 +690,12 @@ public:
 
   /* initializes a new tape
    * - returns 0 on success
-   * - returns 1 in case tapeId is already/still in use */
+   * - returns 1 in case tape is already/still in use */
   int initNewTape();
 
   // ------------------- Combined methods ------------------------
   // opens an existing tape or creates a new one
   void openTape();
-
-  // updates the tape infos for the given ID - a tapeInfos struct is created
-  // and registered if non is found but its state will remain "not in use"
-  std::shared_ptr<ValueTape> getTapeInfos(short tapeId);
 
   // close open tapes, update stats and clean up
   void close_tape(int flag);
@@ -718,7 +711,7 @@ public:
    */
   /* forward call after setting the parameters. */
   /****************************************************************************/
-  void set_param_vec(short tag, size_t numparam, const double *paramvec);
+  void set_param_vec(size_t numparam, const double *paramvec);
   void save_params();
   /****************************************************************************/
   /* Frees parameter indices after taping is complete */

--- a/ADOL-C/src/adouble.cpp
+++ b/ADOL-C/src/adouble.cpp
@@ -21,7 +21,7 @@
 #include <adolc/valuetape/valuetape.h>
 
 adouble::adouble() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
 
 #if defined(ADOLC_ADOUBLE_STDCZERO)
   if (tape.traceFlag()) {
@@ -47,7 +47,7 @@ adouble::adouble() {
 }
 
 adouble::adouble(double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
 
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -80,7 +80,7 @@ adouble::adouble(double coval) {
 }
 
 adouble::adouble(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(a.loc())) {
@@ -127,7 +127,7 @@ adouble::adouble(const adouble &a) {
 /*                                                              ASSIGNMENTS */
 
 adouble &adouble::operator=(double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -160,7 +160,7 @@ adouble &adouble::operator=(double coval) {
 }
 
 adouble &adouble::operator=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   /* test this to avoid for x=x statements adjoint(x)=0 in reverse mode */
   if (loc() != a.loc()) {
     if (tape.traceFlag()) {
@@ -205,7 +205,7 @@ adouble &adouble::operator=(const adouble &a) {
 }
 
 adouble &adouble::operator=(const pdouble &p) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(assign_p);
@@ -229,7 +229,7 @@ adouble &adouble::operator=(const pdouble &p) {
 /*                       ARITHMETIC ASSIGNMENT                             */
 
 adouble &adouble::operator+=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -250,7 +250,7 @@ adouble &adouble::operator+=(const double coval) {
 }
 
 adouble &adouble::operator+=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(a.loc()) && tape.get_active_value(loc())) {
@@ -303,7 +303,7 @@ adouble &adouble::operator+=(const adouble &a) {
 }
 
 adouble &adouble::operator+=(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   int upd = 0;
   if (tape.traceFlag())
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -374,7 +374,7 @@ adouble &adouble::operator+=(adouble &&a) {
 }
 
 adouble &adouble::operator-=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -395,7 +395,7 @@ adouble &adouble::operator-=(const double coval) {
 }
 
 adouble &adouble::operator-=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(a.loc()) && tape.get_active_value(loc())) {
@@ -448,7 +448,7 @@ adouble &adouble::operator-=(const adouble &a) {
 }
 
 adouble &adouble::operator-=(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   int upd = 0;
   if (tape.traceFlag())
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -518,7 +518,7 @@ adouble &adouble::operator-=(adouble &&a) {
 }
 
 adouble &adouble::operator*=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -540,7 +540,7 @@ adouble &adouble::operator*=(const double coval) {
 }
 
 adouble &adouble::operator*=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(a.loc()) && tape.get_active_value(loc())) {
@@ -598,7 +598,7 @@ adouble &adouble::operator*=(const adouble &a) {
 /*                       INCREMENT / DECREMENT                              */
 
 adouble adouble::operator++(int) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   // create adouble to store old state in it.
   adouble ret_adouble;
 
@@ -663,7 +663,7 @@ adouble adouble::operator++(int) {
 }
 
 adouble adouble::operator--(int) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   // create adouble to store old state in it.
   adouble ret_adouble;
 
@@ -728,7 +728,7 @@ adouble adouble::operator--(int) {
 }
 
 adouble &adouble::operator++() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -748,7 +748,7 @@ adouble &adouble::operator++() {
 }
 
 adouble &adouble::operator--() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 #if defined(ADOLC_TRACK_ACTIVITY)
     if (tape.get_active_value(loc())) {
@@ -775,7 +775,7 @@ adouble &adouble::operator--() {
 // Assign a double value to an adouble and mark the adouble as independent on
 // the tape
 adouble &adouble::operator<<=(const double input) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.increment_numInds();
     tape.put_op(assign_ind);
@@ -797,7 +797,7 @@ adouble &adouble::operator<<=(const double input) {
 // reference can be seen as output value of the function given by the trace
 // of the adouble.
 adouble &adouble::operator>>=(double &output) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
 #if defined(ADOLC_TRACK_ACTIVITY)
   if (!tape.get_active_value(loc())) {
     fprintf(DIAG_OUT, "ADOL-C warning: marking an inactive variable (constant) "
@@ -834,7 +834,7 @@ adouble &adouble::operator>>=(double &output) {
 }
 
 void adouble::declareIndependent() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.increment_numInds();
 
@@ -851,7 +851,7 @@ void adouble::declareIndependent() {
 }
 
 void adouble::declareDependent() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
 #if defined(ADOLC_TRACK_ACTIVITY)
   if (!tape.get_active_value(loc())) {
     fprintf(DIAG_OUT, "ADOL-C warning: marking an inactive variable (constant) "
@@ -891,7 +891,7 @@ std::ostream &operator<<(std::ostream &out, const adouble &a) {
 }
 
 std::istream &operator>>(std::istream &in, adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   double coval;
   in >> coval;
   if (tape.traceFlag()) {
@@ -931,7 +931,7 @@ std::istream &operator>>(std::istream &in, adouble &a) {
 #ifdef ADOLC_ADVANCED_BRANCHING
 
 adouble operator!=(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   adouble ret_adouble;
@@ -954,7 +954,7 @@ adouble operator!=(const adouble &a, const adouble &b) {
 }
 
 adouble operator!=(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval != b_coval);
@@ -978,7 +978,7 @@ adouble operator!=(adouble &&a, const adouble &b) {
 adouble operator!=(const adouble &a, adouble &&b) { return std::move(b) != a; }
 
 adouble operator==(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double a_coval = a.value();
@@ -1000,7 +1000,7 @@ adouble operator==(const adouble &a, const adouble &b) {
 }
 
 adouble operator==(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval == b_coval);
@@ -1024,7 +1024,7 @@ adouble operator==(adouble &&a, const adouble &b) {
 adouble operator==(const adouble &a, adouble &&b) { return std::move(b) == a; }
 
 adouble operator<=(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double a_coval = a.value();
@@ -1046,7 +1046,7 @@ adouble operator<=(const adouble &a, const adouble &b) {
 }
 
 adouble operator<=(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval <= b_coval);
@@ -1068,7 +1068,7 @@ adouble operator<=(adouble &&a, const adouble &b) {
 }
 
 adouble operator<=(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval <= b_coval);
@@ -1089,7 +1089,7 @@ adouble operator<=(const adouble &a, adouble &&b) {
   return b;
 }
 adouble operator>=(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double a_coval = a.value();
@@ -1111,7 +1111,7 @@ adouble operator>=(const adouble &a, const adouble &b) {
 }
 
 adouble operator>=(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval >= b_coval);
@@ -1133,7 +1133,7 @@ adouble operator>=(adouble &&a, const adouble &b) {
 }
 
 adouble operator>=(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval >= b_coval);
@@ -1155,7 +1155,7 @@ adouble operator>=(const adouble &a, adouble &&b) {
 }
 
 adouble operator<(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double a_coval = a.value();
@@ -1177,7 +1177,7 @@ adouble operator<(const adouble &a, const adouble &b) {
 }
 
 adouble operator<(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval < b_coval);
@@ -1199,7 +1199,7 @@ adouble operator<(adouble &&a, const adouble &b) {
 }
 
 adouble operator<(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval < b_coval);
@@ -1221,7 +1221,7 @@ adouble operator<(const adouble &a, adouble &&b) {
 }
 
 adouble operator>(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double a_coval = a.value();
@@ -1243,7 +1243,7 @@ adouble operator>(const adouble &a, const adouble &b) {
 }
 
 adouble operator>(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval > b_coval);
@@ -1265,7 +1265,7 @@ adouble operator>(adouble &&a, const adouble &b) {
 }
 
 adouble operator>(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double a_coval = a.value();
   const double b_coval = b.value();
   const double res = static_cast<double>(a_coval > b_coval);
@@ -1289,7 +1289,7 @@ adouble operator>(const adouble &a, adouble &&b) {
 #endif // ADOLC_ADVANCED_BRANCHING
 
 bool operator!=(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a != 0);
   else {
@@ -1315,7 +1315,7 @@ bool operator!=(const double coval, const adouble &a) {
 }
 
 bool operator==(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a == 0);
   else {
@@ -1341,7 +1341,7 @@ inline bool operator==(const double coval, const adouble &a) {
 }
 
 bool operator<=(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a <= 0);
   else {
@@ -1368,7 +1368,7 @@ inline bool operator<=(const double coval, const adouble &a) {
 }
 
 bool operator>=(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a >= 0);
   else {
@@ -1395,7 +1395,7 @@ bool operator>=(const double coval, const adouble &a) {
 }
 
 bool operator<(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a < 0);
   else {
@@ -1422,7 +1422,7 @@ bool operator<(const double coval, const adouble &a) {
 }
 
 bool operator>(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (coval != 0.0)
     return (-coval + a > 0);
   else {
@@ -1452,7 +1452,7 @@ bool operator>(const double coval, const adouble &a) {
 /*                           SIGN  OPERATORS */
 
 adouble operator+(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = a.value();
 
@@ -1497,7 +1497,7 @@ adouble operator+(const adouble &a) {
 }
 
 adouble operator+(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
 
   if (tape.traceFlag()) {
 
@@ -1538,7 +1538,7 @@ adouble operator+(adouble &&a) {
 }
 
 adouble operator-(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = a.value();
 
@@ -1586,7 +1586,7 @@ adouble operator-(const adouble &a) {
 }
 
 adouble operator-(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = a.value();
 
   if (tape.traceFlag()) {
@@ -1632,7 +1632,7 @@ adouble operator-(adouble &&a) {
 /*                            BINARY OPERATORS                              */
 
 adouble operator+(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = a.value() + b.value();
 
@@ -1713,7 +1713,7 @@ adouble operator+(const adouble &a, const adouble &b) {
 }
 
 adouble operator+(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = a.value() + b.value();
 
   if (tape.traceFlag()) {
@@ -1792,7 +1792,7 @@ adouble operator+(adouble &&a, const adouble &b) {
 }
 
 adouble operator+(const double coval, const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = coval + a.value();
 
@@ -1847,7 +1847,7 @@ adouble operator+(const double coval, const adouble &a) {
 }
 
 adouble operator+(const double coval, adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = coval + a.value();
 
   if (tape.traceFlag()) {
@@ -1897,7 +1897,7 @@ adouble operator+(const double coval, adouble &&a) {
 }
 
 adouble operator-(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = a.value() - b.value();
 
@@ -1977,7 +1977,7 @@ adouble operator-(const adouble &a, const adouble &b) {
 }
 
 adouble operator-(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = a.value() - b.value();
 
   if (tape.traceFlag()) {
@@ -2056,7 +2056,7 @@ adouble operator-(adouble &&a, const adouble &b) {
 }
 
 adouble operator-(const double coval, const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = coval - a.value();
 
@@ -2111,7 +2111,7 @@ adouble operator-(const double coval, const adouble &a) {
 }
 
 adouble operator-(const double coval, adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = coval - a.value();
 
   if (tape.traceFlag()) {
@@ -2162,7 +2162,7 @@ adouble operator-(const double coval, adouble &&a) {
 }
 
 adouble operator*(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = a.value() * b.value();
 
@@ -2246,7 +2246,7 @@ adouble operator*(const adouble &a, const adouble &b) {
 }
 
 adouble operator*(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = a.value() * b.value();
 
   if (tape.traceFlag()) {
@@ -2329,7 +2329,7 @@ adouble operator*(adouble &&a, const adouble &b) {
 }
 
 adouble operator*(const double coval, const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = coval * a.value();
 
@@ -2389,7 +2389,7 @@ adouble operator*(const double coval, const adouble &a) {
 }
 
 adouble operator*(const double coval, adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = coval * a.value();
   if (tape.traceFlag()) {
 
@@ -2442,7 +2442,7 @@ adouble operator*(const double coval, adouble &&a) {
 }
 
 adouble operator/(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = a.value() / b.value();
 
@@ -2529,7 +2529,7 @@ adouble operator/(const adouble &a, const adouble &b) {
 }
 
 adouble operator/(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = a.value() / b.value();
 
   if (tape.traceFlag()) {
@@ -2597,7 +2597,7 @@ adouble operator/(adouble &&a, const adouble &b) {
 }
 
 adouble operator/(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = a.value() / b.value();
 
   if (tape.traceFlag()) {
@@ -2665,7 +2665,7 @@ adouble operator/(const adouble &a, adouble &&b) {
 }
 
 adouble operator/(const double coval, const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double coval2 = coval / a.value();
@@ -2715,7 +2715,7 @@ adouble operator/(const double coval, const adouble &a) {
 }
 
 adouble operator/(const double coval, adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = coval / a.value();
 
   if (tape.traceFlag()) {
@@ -2767,7 +2767,7 @@ adouble operator/(const double coval, adouble &&a) {
 /*                          UNARY OPERATIONS                                */
 
 adouble exp(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::exp(a.value());
   if (tape.traceFlag()) {
@@ -2811,7 +2811,7 @@ adouble exp(const adouble &a) {
 }
 
 adouble exp(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::exp(a.value());
 
   if (tape.traceFlag()) {
@@ -2859,7 +2859,7 @@ adouble exp(adouble &&a) {
 }
 
 adouble log(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::log(a.value());
 
@@ -2909,7 +2909,7 @@ adouble log(const adouble &a) {
 }
 
 adouble log(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::log(a.value());
 
   if (tape.traceFlag()) {
@@ -2958,7 +2958,7 @@ adouble log(adouble &&a) {
 }
 
 adouble sqrt(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::sqrt(a.value());
 
@@ -3008,7 +3008,7 @@ adouble sqrt(const adouble &a) {
 }
 
 adouble sqrt(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::sqrt(a.value());
 
   if (tape.traceFlag()) {
@@ -3057,7 +3057,7 @@ adouble sqrt(adouble &&a) {
 }
 
 adouble cbrt(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::cbrt(a.value());
 
@@ -3107,7 +3107,7 @@ adouble cbrt(const adouble &a) {
 }
 
 adouble cbrt(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::cbrt(a.value());
 
   if (tape.traceFlag()) {
@@ -3152,7 +3152,7 @@ adouble cbrt(adouble &&a) {
 }
 
 adouble sin(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double coval1 = ADOLC_MATH_NSP::sin(a.value());
@@ -3233,7 +3233,7 @@ adouble sin(const adouble &a) {
 }
 
 adouble sin(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval1 = ADOLC_MATH_NSP::sin(a.value());
   const double coval2 = ADOLC_MATH_NSP::cos(a.value());
 
@@ -3313,7 +3313,7 @@ adouble sin(adouble &&a) {
 }
 
 adouble cos(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   const double coval1 = ADOLC_MATH_NSP::cos(a.value());
@@ -3397,7 +3397,7 @@ adouble cos(const adouble &a) {
 }
 
 adouble cos(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval1 = ADOLC_MATH_NSP::cos(a.value());
   const double coval2 = ADOLC_MATH_NSP::sin(a.value());
 
@@ -3479,7 +3479,7 @@ adouble cos(adouble &&a) {
 }
 
 adouble asin(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::asin(a.value());
   adouble b = 1.0 / sqrt(1.0 - a * a);
@@ -3535,7 +3535,7 @@ adouble asin(const adouble &a) {
 }
 
 adouble asin(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::asin(a.value());
   adouble b = 1.0 / sqrt(1.0 - a * a);
 
@@ -3590,7 +3590,7 @@ adouble asin(adouble &&a) {
 }
 
 adouble acos(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::acos(a.value());
 
@@ -3647,7 +3647,7 @@ adouble acos(const adouble &a) {
 }
 
 adouble acos(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::acos(a.value());
 
   adouble b = -1.0 / sqrt(1.0 - a * a);
@@ -3699,7 +3699,7 @@ adouble acos(adouble &&a) {
 }
 
 adouble atan(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::atan(a.value());
 
@@ -3756,7 +3756,7 @@ adouble atan(const adouble &a) {
 }
 
 adouble atan(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::atan(a.value());
 
   adouble b = 1.0 / (1.0 + a * a);
@@ -3808,7 +3808,7 @@ adouble atan(adouble &&a) {
 }
 
 adouble asinh(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP_ERF::asinh(a.value());
   adouble b = 1.0 / sqrt(1.0 + a * a);
@@ -3864,7 +3864,7 @@ adouble asinh(const adouble &a) {
 }
 
 adouble asinh(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP_ERF::asinh(a.value());
   adouble b = 1.0 / sqrt(1.0 + a * a);
 
@@ -3915,7 +3915,7 @@ adouble asinh(adouble &&a) {
 }
 
 adouble acosh(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP_ERF::acosh(a.value());
   adouble b = 1.0 / sqrt(a * a - 1.0);
@@ -3971,7 +3971,7 @@ adouble acosh(const adouble &a) {
 }
 
 adouble acosh(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP_ERF::acosh(a.value());
   adouble b = 1.0 / sqrt(a * a - 1.0);
 
@@ -4022,7 +4022,7 @@ adouble acosh(adouble &&a) {
 }
 
 adouble atanh(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP_ERF::atanh(a.value());
   adouble b = 1.0 / (1.0 - a * a);
@@ -4078,7 +4078,7 @@ adouble atanh(const adouble &a) {
 }
 
 adouble atanh(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP_ERF::atanh(a.value());
   adouble b = 1.0 / (1.0 - a * a);
 
@@ -4129,7 +4129,7 @@ adouble atanh(adouble &&a) {
 }
 
 adouble erf(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP_ERF::erf(a.value());
   adouble b =
@@ -4186,7 +4186,7 @@ adouble erf(const adouble &a) {
 }
 
 adouble erf(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP_ERF::erf(a.value());
   adouble b =
       2.0 / ADOLC_MATH_NSP_ERF::sqrt(ADOLC_MATH_NSP::acos(-1.0)) * exp(-a * a);
@@ -4238,7 +4238,7 @@ adouble erf(adouble &&a) {
 }
 
 adouble erfc(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP_ERF::erfc(a.value());
   adouble b =
@@ -4294,7 +4294,7 @@ adouble erfc(const adouble &a) {
 }
 
 adouble erfc(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP_ERF::erfc(a.value());
   adouble b =
       -2.0 / ADOLC_MATH_NSP_ERF::sqrt(ADOLC_MATH_NSP::acos(-1.0)) * exp(-a * a);
@@ -4345,7 +4345,7 @@ adouble erfc(adouble &&a) {
 }
 
 adouble ceil(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::ceil(a.value());
 
@@ -4397,7 +4397,7 @@ adouble ceil(const adouble &a) {
 }
 
 adouble ceil(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::ceil(a.value());
 
   if (tape.traceFlag()) {
@@ -4444,7 +4444,7 @@ adouble ceil(adouble &&a) {
 }
 
 adouble floor(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval = ADOLC_MATH_NSP::floor(a.value());
 
@@ -4496,7 +4496,7 @@ adouble floor(const adouble &a) {
 }
 
 adouble floor(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval = ADOLC_MATH_NSP::floor(a.value());
 
   if (tape.traceFlag()) {
@@ -4544,7 +4544,7 @@ adouble floor(adouble &&a) {
 }
 
 adouble fabs(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double temp = ADOLC_MATH_NSP::fabs(a.value());
   const double coval = temp != a.value() ? 0.0 : 1.0;
@@ -4600,7 +4600,7 @@ adouble fabs(const adouble &a) {
 }
 
 adouble fabs(adouble &&a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double temp = ADOLC_MATH_NSP::fabs(a.value());
   const double coval = temp != a.value() ? 0.0 : 1.0;
 
@@ -4651,7 +4651,7 @@ adouble fabs(adouble &&a) {
 }
 
 adouble fmin(const adouble &a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.no_min_max())
     return ((a + b - fabs(a - b)) / 2.0);
 
@@ -4758,7 +4758,7 @@ adouble fmin(const adouble &a, const adouble &b) {
 }
 
 adouble fmin(adouble &&a, const adouble &b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.no_min_max())
     return ((a + b - fabs(a - b)) / 2.0);
 
@@ -4863,7 +4863,7 @@ adouble fmin(adouble &&a, const adouble &b) {
 }
 
 adouble fmin(const adouble &a, adouble &&b) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.no_min_max())
     return ((a + b - fabs(a - b)) / 2.0);
 
@@ -4968,7 +4968,7 @@ adouble fmin(const adouble &a, adouble &&b) {
 }
 
 adouble pow(const adouble &a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   const double coval2 = ADOLC_MATH_NSP::pow(a.value(), coval);
 
@@ -5021,7 +5021,7 @@ adouble pow(const adouble &a, const double coval) {
 }
 
 adouble pow(adouble &&a, const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const double coval2 = ADOLC_MATH_NSP::pow(a.value(), coval);
 
   if (tape.traceFlag()) {
@@ -5074,7 +5074,7 @@ adouble pow(adouble &&a, const double coval) {
 /* the same argument point otherwise it stops with a returnval */
 #define extend_quad(func, integrand)                                           \
   adouble func(const adouble &arg) {                                           \
-    ValueTape &tape = currentTape();                                           \
+    auto &tape = *currentTapePtr();                                            \
     adouble temp;                                                              \
     adouble val;                                                               \
     integrand;                                                                 \
@@ -5108,7 +5108,7 @@ double myquad(double x) {
 
 void condassign(adouble &res, const adouble &cond, const adouble &arg1,
                 const adouble &arg2) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -5236,7 +5236,7 @@ void condassign(adouble &res, const adouble &cond, const adouble &arg1,
 }
 
 void condassign(adouble &res, const adouble &cond, const adouble &arg) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -5333,7 +5333,7 @@ void condassign(adouble &res, const adouble &cond, const adouble &arg) {
 
 void condeqassign(adouble &res, const adouble &cond, const adouble &arg1,
                   const adouble &arg2) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -5463,7 +5463,7 @@ void condeqassign(adouble &res, const adouble &cond, const adouble &arg1,
 }
 
 void condeqassign(adouble &res, const adouble &cond, const adouble &arg) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
 #if defined(ADOLC_TRACK_ACTIVITY)
@@ -5560,7 +5560,7 @@ void condeqassign(adouble &res, const adouble &cond, const adouble &arg) {
 
 void adolc_vec_copy(adouble *const dest, const adouble *const src,
                     size_t size) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (dest[size - 1].loc() - dest[0].loc() != size - 1 ||
       src[size - 1].loc() - src[0].loc() != size - 1)
     ADOLCError::fail(ADOLCError::ErrorType::VEC_LOCATIONGAP, CURRENT_LOCATION);
@@ -5584,7 +5584,7 @@ void adolc_vec_copy(adouble *const dest, const adouble *const src,
 // requires a and b to be of size "size"
 adouble adolc_vec_dot(const adouble *const vec_a, const adouble *const vec_b,
                       size_t size) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (vec_a[size - 1].loc() - vec_a[0].loc() != size - 1 ||
       vec_b[size - 1].loc() - vec_b[0].loc() != size - 1)
     ADOLCError::fail(ADOLCError::ErrorType::VEC_LOCATIONGAP, CURRENT_LOCATION);
@@ -5620,7 +5620,7 @@ adouble adolc_vec_dot(const adouble *const vec_a, const adouble *const vec_b,
 void adolc_vec_axpy(adouble *const res, const adouble &a,
                     const adouble *const vec_a, const adouble *const vec_b,
                     size_t size) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (res[size - 1].loc() - res[0].loc() != size - 1 ||
       vec_a[size - 1].loc() - vec_a[0].loc() != size - 1 ||
       vec_b[size - 1].loc() - vec_b[0].loc() != size - 1)

--- a/ADOL-C/src/advector.cpp
+++ b/ADOL-C/src/advector.cpp
@@ -23,7 +23,7 @@
 #include <limits>
 
 adubref::adubref(size_t lo, size_t ref) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   loc_ = lo;
   refloc_ = static_cast<size_t>(trunc(fabs(tape.get_ad_value(loc_))));
 
@@ -34,10 +34,10 @@ adubref::adubref(size_t lo, size_t ref) {
   }
 }
 
-adubref::~adubref() { currentTape().free_loc(loc_); }
+adubref::~adubref() { currentTapePtr()->free_loc(loc_); }
 
 adubref &adubref::operator=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     if (coval == 0) {
 
@@ -63,7 +63,7 @@ adubref &adubref::operator=(const double coval) {
 }
 
 adubref &adubref::operator=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   /* test this to avoid for x=x statements adjoint(x)=0 in reverse mode */
   if (loc_ != a.loc()) {
     if (tape.traceFlag()) {
@@ -84,7 +84,7 @@ adubref &adubref::operator=(const adouble &a) {
 }
 
 adubref::operator adouble() const {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   if (tape.traceFlag()) {
@@ -104,7 +104,7 @@ adubref::operator adouble() const {
 }
 
 adouble adubref::operator++(int) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   if (tape.traceFlag()) {
@@ -136,7 +136,7 @@ adouble adubref::operator++(int) {
 }
 
 adouble adubref::operator--(int) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
 
   if (tape.traceFlag()) {
@@ -168,7 +168,7 @@ adouble adubref::operator--(int) {
 }
 
 adubref &adubref::operator++() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_incr_a);
@@ -184,7 +184,7 @@ adubref &adubref::operator++() {
 }
 
 adubref &adubref::operator--() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_decr_a);
@@ -201,7 +201,7 @@ adubref &adubref::operator--() {
 }
 
 adubref &adubref::operator+=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_eq_plus_d);
@@ -219,7 +219,7 @@ adubref &adubref::operator+=(const double coval) {
 }
 
 adubref &adubref::operator+=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.put_op(ref_eq_plus_a);
     tape.put_loc(a.loc()); // = arg
@@ -236,7 +236,7 @@ adubref &adubref::operator+=(const adouble &a) {
 }
 
 adubref &adubref::operator-=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_eq_min_d);
@@ -254,7 +254,7 @@ adubref &adubref::operator-=(const double coval) {
 }
 
 adubref &adubref::operator-=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_eq_min_a);
@@ -272,7 +272,7 @@ adubref &adubref::operator-=(const adouble &a) {
 }
 
 adubref &adubref::operator*=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_eq_mult_d);
@@ -290,7 +290,7 @@ adubref &adubref::operator*=(const double coval) {
 }
 
 adubref &adubref::operator*=(const adouble &a) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_eq_mult_a);
@@ -308,7 +308,7 @@ adubref &adubref::operator*=(const adouble &a) {
 }
 
 adubref &adubref::operator<<=(const double coval) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.increment_numInds();
 
@@ -327,7 +327,7 @@ adubref &adubref::operator<<=(const double coval) {
 }
 
 void adubref::declareIndependent() {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.increment_numInds();
 
@@ -350,7 +350,7 @@ void adubref::declareDependent() { adouble(*this).declareDependent(); }
 
 void condassign(adubref &res, const adouble &cond, const adouble &arg1,
                 const adouble &arg2) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
     tape.put_op(ref_cond_assign);
     tape.put_loc(cond.loc()); // = arg
@@ -372,7 +372,7 @@ void condassign(adubref &res, const adouble &cond, const adouble &arg1,
 }
 
 void condassign(adubref &res, const adouble &cond, const adouble &arg) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_cond_assign_s);
@@ -393,7 +393,7 @@ void condassign(adubref &res, const adouble &cond, const adouble &arg) {
 
 void condeqassign(adubref &res, const adouble &cond, const adouble &arg1,
                   const adouble &arg2) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_cond_eq_assign);
@@ -416,7 +416,7 @@ void condeqassign(adubref &res, const adouble &cond, const adouble &arg1,
 }
 
 void condeqassign(adubref &res, const adouble &cond, const adouble &arg) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   if (tape.traceFlag()) {
 
     tape.put_op(ref_cond_eq_assign_s);
@@ -444,7 +444,7 @@ bool advector::nondecreasing() const {
 }
 
 adouble advector::operator[](const adouble &index) const {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const size_t idx = (size_t)trunc(fabs(index.value()));
   adouble ret_adouble;
 
@@ -470,7 +470,7 @@ adouble advector::operator[](const adouble &index) const {
 }
 
 adubref advector::operator[](const adouble &index) {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   const size_t idx = (size_t)trunc(fabs(index.value()));
   size_t locat = tape.next_loc();
   size_t n = data_.size();

--- a/ADOL-C/src/drivers/driversf.cpp
+++ b/ADOL-C/src/drivers/driversf.cpp
@@ -18,8 +18,6 @@ This file is part of ADOL-C. This software is provided as open source.
 #include <adolc/fortutils.h>
 #include <adolc/interfaces.h>
 
-#include <math.h>
-
 BEGIN_C_DECLS
 
 /****************************************************************************/
@@ -28,15 +26,14 @@ BEGIN_C_DECLS
 /*--------------------------------------------------------------------------*/
 /*                                                                 function */
 /* function(tag, m, n, x[n], y[m])                                          */
-fint function_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
+fint function_(ValueTape &tape, fint *fm, fint *fn, fdouble *fargument,
                fdouble *fresult) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn);
   double *argument = myalloc1(n);
   double *result = myalloc1(m);
   spread1(n, fargument, argument);
-  rc = function(tag, m, n, argument, result);
+  rc = function(tape, m, n, argument, result);
   pack1(m, result, fresult);
   myfree1(argument);
   myfree1(result);
@@ -46,14 +43,14 @@ fint function_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
 /*--------------------------------------------------------------------------*/
 /*                                                                 gradient */
 /* gradient(tag, n, x[n], g[n])                                             */
-fint gradient_(fint *ftag, fint *fn, fdouble *fargument, fdouble *fresult) {
+fint gradient_(ValueTape &tape, fint *fn, fdouble *fargument,
+               fdouble *fresult) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int n = static_cast<int>(*fn);
   double *argument = myalloc1(n);
   double *result = myalloc1(n);
   spread1(n, fargument, argument);
-  rc = gradient(tag, n, argument, result);
+  rc = gradient(tape, n, argument, result);
   pack1(n, result, fresult);
   myfree1(result);
   myfree1(argument);
@@ -63,10 +60,9 @@ fint gradient_(fint *ftag, fint *fn, fdouble *fargument, fdouble *fresult) {
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /* vec_jac(tag, m, n, repeat, x[n], u[m], v[n])                             */
-fint vec_jac_(fint *ftag, fint *fm, fint *fn, fint *frepeat, fdouble *fargument,
-              const fdouble *flagrange, fdouble *frow) {
+fint vec_jac_(ValueTape &tape, fint *fm, fint *fn, fint *frepeat,
+              fdouble *fargument, const fdouble *flagrange, fdouble *frow) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       repeat = static_cast<int>(*frepeat);
   double *argument = myalloc1(n);
@@ -74,7 +70,7 @@ fint vec_jac_(fint *ftag, fint *fm, fint *fn, fint *frepeat, fdouble *fargument,
   double *row = myalloc1(n);
   spread1(m, flagrange, lagrange);
   spread1(n, fargument, argument);
-  rc = vec_jac(tag, m, n, repeat, argument, lagrange, row);
+  rc = vec_jac(tape, m, n, repeat, argument, lagrange, row);
   pack1(n, row, frow);
   myfree1(argument);
   myfree1(lagrange);
@@ -85,15 +81,14 @@ fint vec_jac_(fint *ftag, fint *fm, fint *fn, fint *frepeat, fdouble *fargument,
 /*--------------------------------------------------------------------------*/
 /*                                                                 jacobian */
 /* jacobian(tag, m, n, x[n], J[m][n])                                       */
-fint jacobian_(fint *ftag, fint *fdepen, fint *findep, fdouble *fargument,
+fint jacobian_(ValueTape &tape, fint *fdepen, fint *findep, fdouble *fargument,
                fdouble *fjac) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int depen = static_cast<int>(*fdepen), indep = static_cast<int>(*findep);
   double **Jac = myalloc2(depen, indep);
   double *argument = myalloc1(indep);
   spread1(indep, fargument, argument);
-  rc = jacobian(tag, depen, indep, argument, Jac);
+  rc = jacobian(tape, depen, indep, argument, Jac);
   pack2(depen, indep, Jac, fjac);
   myfree2(Jac);
   myfree1(argument);
@@ -103,17 +98,16 @@ fint jacobian_(fint *ftag, fint *fdepen, fint *findep, fdouble *fargument,
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /* jac_vec(tag, m, n, x[n], v[n], u[m]);                                    */
-fint jac_vec_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
+fint jac_vec_(ValueTape &tape, fint *fm, fint *fn, fdouble *fargument,
               fdouble *ftangent, fdouble *fcolumn) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn);
   double *argument = myalloc1(n);
   double *tangent = myalloc1(n);
   double *column = myalloc1(m);
   spread1(n, ftangent, tangent);
   spread1(n, fargument, argument);
-  rc = jac_vec(tag, m, n, argument, tangent, column);
+  rc = jac_vec(tape, m, n, argument, tangent, column);
   pack1(m, column, fcolumn);
   myfree1(argument);
   myfree1(tangent);
@@ -124,17 +118,16 @@ fint jac_vec_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /* hess_vec(tag, n, x[n], v[n], w[n])                                       */
-fint hess_vec_(fint *ftag, fint *fn, fdouble *fargument, fdouble *ftangent,
+fint hess_vec_(ValueTape &tape, fint *fn, fdouble *fargument, fdouble *ftangent,
                fdouble *fresult) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int n = static_cast<int>(*fn);
   double *argument = myalloc1(n);
   double *tangent = myalloc1(n);
   double *result = myalloc1(n);
   spread1(n, fargument, argument);
   spread1(n, ftangent, tangent);
-  rc = hess_vec(tag, n, argument, tangent, result);
+  rc = hess_vec(tape, n, argument, tangent, result);
   pack1(n, result, fresult);
   myfree1(argument);
   myfree1(tangent);
@@ -145,17 +138,16 @@ fint hess_vec_(fint *ftag, fint *fn, fdouble *fargument, fdouble *ftangent,
 /*--------------------------------------------------------------------------*/
 /*                                                                  hessian */
 /* hessian(tag, n, x[n], lower triangle of H[n][n])                         */
-fint hessian_(fint *ftag, fint *fn, fdouble *fx,
+fint hessian_(ValueTape &tape, fint *fn, fdouble *fx,
               fdouble *fh) /* length of h should be n*n but the
                             upper half of this matrix remains unchanged */
 {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int n = static_cast<int>(*fn);
   double **H = myalloc2(n, n);
   double *x = myalloc1(n);
   spread1(n, fx, x);
-  rc = hessian(tag, n, x, H);
+  rc = hessian(tape, n, x, H);
   pack2(n, n, H, fh);
   myfree2(H);
   myfree1(x);
@@ -165,10 +157,9 @@ fint hessian_(fint *ftag, fint *fn, fdouble *fx,
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /* lagra_hess_vec(tag, m, n, x[n], v[n], u[m], w[n])                        */
-fint lagra_hess_vec_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
+fint lagra_hess_vec_(ValueTape &tape, fint *fm, fint *fn, fdouble *fargument,
                      fdouble *ftangent, fdouble *flagrange, fdouble *fresult) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn);
   double *argument = myalloc1(n);
   double *tangent = myalloc1(n);
@@ -177,7 +168,7 @@ fint lagra_hess_vec_(fint *ftag, fint *fm, fint *fn, fdouble *fargument,
   spread1(n, fargument, argument);
   spread1(n, ftangent, tangent);
   spread1(m, flagrange, lagrange);
-  rc = lagra_hess_vec(tag, m, n, argument, tangent, lagrange, result);
+  rc = lagra_hess_vec(tape, m, n, argument, tangent, lagrange, result);
   pack1(n, result, fresult);
   myfree1(argument);
   myfree1(tangent);

--- a/ADOL-C/src/drivers/odedrivers.cpp
+++ b/ADOL-C/src/drivers/odedrivers.cpp
@@ -29,12 +29,12 @@ BEGIN_C_DECLS
 /*--------------------------------------------------------------------------*/
 /*                                                                  forodec */
 /* forodec(tag, n, tau, dold, dnew, X[n][d+1])                              */
-int forodec(short tag,  /* tape identifier */
-            int n,      /* space dimension */
-            double tau, /* scaling defaults to 1.0 */
-            int dol,    /* previous degree defaults to zero */
-            int deg,    /* New degree of consistency        */
-            double **Y) /* Taylor series */
+int forodec(ValueTape &tape, /* tape identifier */
+            int n,           /* space dimension */
+            double tau,      /* scaling defaults to 1.0 */
+            int dol,         /* previous degree defaults to zero */
+            int deg,         /* New degree of consistency        */
+            double **Y)      /* Taylor series */
 {
   /*********************************************************************
     This is assumed to be the autonomous case.
@@ -52,7 +52,6 @@ int forodec(short tag,  /* tape identifier */
   int rc = 3;
   int i, j, k;
   double taut;
-  ValueTape &tape = findTape(tag);
   if (n > tape.forodec_nax() || deg > tape.forodec_dax()) {
     if (tape.forodec_nax()) {
       myfree1(tape.forodec_y());
@@ -79,7 +78,7 @@ int forodec(short tag,  /* tape identifier */
   if (dol == 0) {
     j = dol;                    /* j = 0 */
     k = (deg) * (j == deg - 1); /* keep death values in prepration */
-    MINDEC(rc, zos_forward(tag, n, n, k, tape.forodec_y(), tape.forodec_z()));
+    MINDEC(rc, zos_forward(tape, n, n, k, tape.forodec_y(), tape.forodec_z()));
     /* for  reverse called by jacode   */
     if (rc < 0)
       return rc;
@@ -90,7 +89,7 @@ int forodec(short tag,  /* tape identifier */
   }
   for (j = dol; j < deg; ++j) {
     k = (deg) * (j == deg - 1); /* keep death values in prepration */
-    MINDEC(rc, hos_forward(tag, n, n, j, k, tape.forodec_y(), Y,
+    MINDEC(rc, hos_forward(tape, n, n, j, k, tape.forodec_y(), Y,
                            tape.forodec_z(), tape.forodec_Z()));
     /* for  reverse called by jacode   */
     if (rc < 0)

--- a/ADOL-C/src/drivers/odedriversf.cpp
+++ b/ADOL-C/src/drivers/odedriversf.cpp
@@ -18,8 +18,6 @@
 #include <adolc/fortutils.h>
 #include <adolc/interfaces.h>
 
-#include <math.h>
-
 BEGIN_C_DECLS
 
 /****************************************************************************/
@@ -28,15 +26,14 @@ BEGIN_C_DECLS
 /*--------------------------------------------------------------------------*/
 /*                                                                  forodec */
 /* forodec(tag, n, tau, dold, dnew, X[n][d+1])                              */
-fint forodec_(fint *ftag,    /* tape identifier */
-              fint *fn,      /* space dimension */
-              fdouble *ftau, /* scaling defaults to 1.0 */
-              fint *fdol,    /* previous degree defaults to zero */
-              fint *fdeg,    /* New degree of consistency        */
-              fdouble *fy)   /* Taylor series                    */
+fint forodec_(ValueTape &tape, /* tape identifier */
+              fint *fn,        /* space dimension */
+              fdouble *ftau,   /* scaling defaults to 1.0 */
+              fint *fdol,      /* previous degree defaults to zero */
+              fint *fdeg,      /* New degree of consistency        */
+              fdouble *fy)     /* Taylor series                    */
 {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int n = static_cast<int>(*fn), dol = static_cast<int>(*fdol),
       deg = static_cast<int>(*fdeg);
   int i;
@@ -44,7 +41,7 @@ fint forodec_(fint *ftag,    /* tape identifier */
   double **Y = myalloc2(n, deg + 1);
   for (i = 0; i < n; i++)
     *Y[i] = fy[i];
-  rc = forodec(tag, n, tau, dol, deg, Y);
+  rc = forodec(tape, n, tau, dol, deg, Y);
   pack2(n, deg + 1, Y, fy);
   free((char *)*Y);
   free((char *)Y);

--- a/ADOL-C/src/drivers/psdriversf.cpp
+++ b/ADOL-C/src/drivers/psdriversf.cpp
@@ -27,12 +27,11 @@ BEGIN_C_DECLS
 /*                                                          abs-normal form */
 /* abs_normal(tag,m,n,s,x[n],sig[s],y[m],z[s],cz[s],cy[m],                  */
 /*            J[m][n],Y[m][s],Z[s][n],L[s][s])                              */
-fint abs_normal_(fint *ftag, fint *fdepen, fint *findep, fint *fswchk,
+fint abs_normal_(ValueTape &tape, fint *fdepen, fint *findep, fint *fswchk,
                  fdouble *fx, fdouble *fy, fdouble *fz, fdouble *fcz,
                  fdouble *fcy, fdouble *fJ, fdouble *fY, fdouble *fZ,
                  fdouble *fL) {
   int rc = -1;
-  short tag = (short)*ftag;
   int m = (int)*fdepen, n = (int)*findep, s = (int)*fswchk;
   double **J, **Y, **Z, **L;
   double *cy, *cz, *x, *y, *z;
@@ -46,7 +45,7 @@ fint abs_normal_(fint *ftag, fint *fdepen, fint *findep, fint *fswchk,
   y = myalloc1(m);
   z = myalloc1(s);
   spread1(n, fx, x);
-  rc = abs_normal(tag, m, n, s, x, y, z, cz, cy, J, Y, Z, L);
+  rc = abs_normal(tape, m, n, s, x, y, z, cz, cy, J, Y, Z, L);
   pack1(m, y, fy);
   pack1(s, z, fz);
   pack1(s, cz, fcz);

--- a/ADOL-C/src/fixpoint.cpp
+++ b/ADOL-C/src/fixpoint.cpp
@@ -206,7 +206,7 @@ static int fp_fos_reverse(ValueTape &outerTape, size_t dim_x, double *x_fix_bar,
   return -1;
 }
 
-void fpi_stack_clear(){ fpi_stack.clear();}
+void fpi_stack_clear() { fpi_stack.clear(); }
 
 int fp_iteration(ValueTape &outerTape, ValueTape &innerTape,
                  double_F double_func, adouble_F adouble_func, norm_F norm_func,

--- a/ADOL-C/src/fixpoint.cpp
+++ b/ADOL-C/src/fixpoint.cpp
@@ -29,7 +29,7 @@
 /* norm(x,dim_x)        */
 struct fpi_data {
   size_t edf_index;
-  short sub_tape_num;
+  ValueTape *innerTapePtr;
   double_F double_func;
   adouble_F adouble_func;
   norm_F norm_func;
@@ -42,7 +42,7 @@ struct fpi_data {
 
 static std::vector<fpi_data> fpi_stack;
 
-static int iteration(short, size_t dim_xu, double *xu, size_t dim_x,
+static int iteration(ValueTape &, size_t dim_xu, double *xu, size_t dim_x,
                      double *x_fix) {
   double err;
   const fpi_data &current = fpi_stack.back();
@@ -69,12 +69,11 @@ static int iteration(short, size_t dim_xu, double *xu, size_t dim_x,
   return -1;
 }
 
-static int fp_zos_forward(short tapeId, size_t dim_xu, double *xu, size_t dim_x,
-                          double *x_fix) {
+static int fp_zos_forward(ValueTape &outerTape, size_t dim_xu, double *xu,
+                          size_t dim_x, double *x_fix) {
 
-  ValueTape &tape = findTape(tapeId);
   double err;
-  const size_t edf_index = tape.ext_diff_fct_index();
+  const size_t edf_index = outerTape.ext_diff_fct_index();
 
   // Find fpi_stack element with index 'edf_index'.
   auto current =
@@ -105,15 +104,14 @@ static int fp_zos_forward(short tapeId, size_t dim_xu, double *xu, size_t dim_x,
   return -1;
 }
 
-static int fp_fos_forward(short tapeId, size_t dim_xu, double *xu,
+static int fp_fos_forward(ValueTape &outerTape, size_t dim_xu, double *xu,
                           double *xu_dot, size_t dim_x, double *x_fix,
                           double *x_fix_dot) {
 
   // Piggy back
   double err, err_deriv;
-  ValueTape &tape = findTape(tapeId);
 
-  const size_t edf_index = tape.ext_diff_fct_index();
+  const size_t edf_index = outerTape.ext_diff_fct_index();
 
   // Find fpi_stack element with index 'edf_index'.
   auto current =
@@ -133,7 +131,7 @@ static int fp_fos_forward(short tapeId, size_t dim_xu, double *xu,
 
     // type signatures of "external driver" and "normal" drivers are not aligned
     // thats why we have to cast...
-    fos_forward(current->sub_tape_num, static_cast<int>(dim_x),
+    fos_forward(*current->innerTapePtr, static_cast<int>(dim_x),
                 static_cast<int>(dim_xu), 0, xu, xu_dot, x_fix, x_fix_dot);
 
     for (size_t i = 0; i < dim_x; ++i)
@@ -153,14 +151,13 @@ static int fp_fos_forward(short tapeId, size_t dim_xu, double *xu,
   return -1;
 }
 
-static int fp_fos_reverse(short tapeId, size_t dim_x, double *x_fix_bar,
+static int fp_fos_reverse(ValueTape &outerTape, size_t dim_x, double *x_fix_bar,
                           size_t dim_xu, double *xu_bar, double * /*unused*/,
                           double * /*unused*/) {
   // (d x_fix) / (d x_0) = 0 (!)
 
   double err = 0.0;
-  ValueTape &tape = findTape(tapeId);
-  const size_t edf_index = tape.ext_diff_fct_index();
+  const size_t edf_index = outerTape.ext_diff_fct_index();
 
   // Find fpi_stack element with index 'edf_index'.
   auto current =
@@ -179,7 +176,7 @@ static int fp_fos_reverse(short tapeId, size_t dim_x, double *x_fix_bar,
 
     // type signatures of "external driver" and "normal" drivers are not aligned
     // thats why we have to cast...
-    fos_reverse(current->sub_tape_num, static_cast<int>(dim_x),
+    fos_reverse(*current->innerTapePtr, static_cast<int>(dim_x),
                 static_cast<int>(dim_xu), xi, U);
 
     for (size_t i = 0; i < dim_x; ++i)
@@ -209,15 +206,17 @@ static int fp_fos_reverse(short tapeId, size_t dim_x, double *x_fix_bar,
   return -1;
 }
 
-int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
-                 adouble_F adouble_func, norm_F norm_func,
+void fpi_stack_clear(){ fpi_stack.clear();}
+
+int fp_iteration(ValueTape &outerTape, ValueTape &innerTape,
+                 double_F double_func, adouble_F adouble_func, norm_F norm_func,
                  norm_deriv_F norm_deriv_func, double epsilon,
                  double epsilon_deriv, size_t N_max, size_t N_max_deriv,
                  adouble *x_0, adouble *u, adouble *x_fix, size_t dim_x,
                  size_t dim_u) {
 
   // declare extern differentiated function and data
-  ext_diff_fct *edf_iteration = reg_ext_fct(tapeId, sub_tape_num, &iteration);
+  ext_diff_fct *edf_iteration = reg_ext_fct(outerTape, innerTape, &iteration);
   edf_iteration->zos_forward = &fp_zos_forward;
   edf_iteration->fos_forward = &fp_fos_forward;
   edf_iteration->fos_reverse = &fp_fos_reverse;
@@ -225,7 +224,7 @@ int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
   // add new fp information
   fpi_stack.emplace_back(fpi_data{
       edf_iteration->index,
-      sub_tape_num,
+      &innerTape,
       double_func,
       adouble_func,
       norm_func,
@@ -238,13 +237,12 @@ int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
   std::vector<double> u_vals(dim_u);
   std::vector<double> x_vals(dim_x);
 
-  ValueTape &tape = findTape(tapeId);
   // ensure that the adoubles are contiguous
-  tape.ensureContiguousLocations(dim_x + dim_u);
+  outerTape.ensureContiguousLocations(dim_x + dim_u);
   // to reset old default later
-  const short last_default_tape_id = currentTape().tapeId();
+  ValueTape *lastDefaultTapePtr = currentTapePtr();
   // ensure that the "new" allocates the adoubles for the "tape"
-  setCurrentTape(tape.tapeId());
+  setCurrentTapePtr(&outerTape);
   // put x and u together
   adouble *xu = new adouble[dim_x + dim_u];
 
@@ -264,8 +262,8 @@ int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
   for (size_t i = 0; i < dim_u; ++i)
     u_vals[i] = xu[dim_x + i].value();
 
-  setCurrentTape(sub_tape_num);
-  currentTape().ensureContiguousLocations(2 * (dim_u + dim_x));
+  setCurrentTapePtr(&innerTape);
+  currentTapePtr()->ensureContiguousLocations(2 * (dim_u + dim_x));
   adouble *x_fix_new = new adouble[dim_u + dim_x];
   adouble *xu_sub_tape = new adouble[dim_u + dim_x];
 
@@ -274,7 +272,7 @@ int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
     x_fix_new[i] = x_vals[i];
 
   // tape near solution
-  trace_on(sub_tape_num, 1);
+  trace_on(innerTape, 1);
 
   for (size_t i = 0; i < dim_x; ++i)
     // xu[i] <<= x_fix[i].value();
@@ -293,15 +291,15 @@ int fp_iteration(short tapeId, short sub_tape_num, double_F double_func,
   for (size_t i = 0; i < dim_x; ++i)
     x_fix_new[i] >>= dummy_out;
 
-  trace_off();
+  trace_off(innerTape);
 
   delete[] xu_sub_tape;
   delete[] x_fix_new;
 
-  setCurrentTape(tapeId);
+  setCurrentTapePtr(&outerTape);
   delete[] xu;
   // reset default tape
-  setCurrentTape(last_default_tape_id);
+  setCurrentTapePtr(lastDefaultTapePtr);
 
   return k;
 }

--- a/ADOL-C/src/fo_rev.cpp
+++ b/ADOL-C/src/fo_rev.cpp
@@ -193,8 +193,7 @@ results   Taylor-Jacobians       ------------          Taylor Jacobians
 #include <adolc/oplate.h>
 #include <adolc/tape_interface.h>
 #include <adolc/valuetape/valuetape.h>
-#include <math.h>
-#include <string.h>
+#include <cmath>
 
 #ifdef ADOLC_MEDIPACK_SUPPORT
 #include <adolc/medipacksupport_p.h>
@@ -217,7 +216,7 @@ BEGIN_C_DECLS
 /****************************************************************************/
 /* Abs-Normal extended adjoint row computation.                             */
 /****************************************************************************/
-int fos_pl_reverse(short tnum,      /* tape id */
+int fos_pl_reverse(ValueTape &tape, /* tape id */
                    int depen,       /* consistency chk on # of deps */
                    int indep,       /* consistency chk on # of indeps */
                    int swchk,       /* consistency chk on # of switches */
@@ -227,16 +226,16 @@ int fos_pl_reverse(short tnum,      /* tape id */
 /****************************************************************************/
 /* Abs-Normal extended adjoint row computation.                             */
 /****************************************************************************/
-int fos_pl_sig_reverse(short tnum, /* tape id */
-                       int depen,  /* consistency chk on # of deps */
-                       int indep,  /* consistency chk on # of indeps */
-                       int swchk,  /* consistency chk on # of switches */
+int fos_pl_sig_reverse(ValueTape &tape, /* tape id */
+                       int depen,       /* consistency chk on # of deps */
+                       int indep,       /* consistency chk on # of indeps */
+                       int swchk,       /* consistency chk on # of switches */
                        const short *siggrad, const double *lagrange,
                        double *results) /*  coefficient vectors */
 #else
-int fos_reverse(short tnum, /* tape id */
-                int depen,  /* consistency chk on # of deps */
-                int indep,  /* consistency chk on # of indeps */
+int fos_reverse(ValueTape &tape, /* tape id */
+                int depen,       /* consistency chk on # of deps */
+                int indep,       /* consistency chk on # of indeps */
                 const double *lagrange,
                 double *results) /*  coefficient vectors */
 
@@ -246,10 +245,10 @@ int fos_reverse(short tnum, /* tape id */
 /* First-Order Vector Reverse Pass.                                         */
 /****************************************************************************/
 
-int fov_reverse(short tnum, /* tape id */
-                int depen,  /* consistency chk on # of deps */
-                int indep,  /* consistency chk on # of indeps */
-                int nrows,  /* # of Jacobian rows being calculated */
+int fov_reverse(ValueTape &tape, /* tape id */
+                int depen,       /* consistency chk on # of deps */
+                int indep,       /* consistency chk on # of indeps */
+                int nrows,       /* # of Jacobian rows being calculated */
                 const double *const *lagrange, /* domain weight vector */
                 double **results) /* matrix of coefficient vectors */
 
@@ -259,7 +258,7 @@ int fov_reverse(short tnum, /* tape id */
 /* First Order Vector version of the reverse mode for bit patterns, tight   */
 /****************************************************************************/
 int int_reverse_tight(
-    short tnum,                    /* tape id                               */
+    ValueTape &tape,               /* tape id                               */
     int depen,                     /* consistency chk on # of deps          */
     int indep,                     /* consistency chk on # of indeps        */
     int nrows,                     /* # of Jacobian rows being calculated   */
@@ -271,7 +270,7 @@ int int_reverse_tight(
 /* First Order Vector version of the reverse mode, bit pattern, safe        */
 /****************************************************************************/
 int int_reverse_safe(
-    short tnum,                    /* tape id                               */
+    ValueTape &tape,               /* tape id                               */
     int depen,                     /* consistency chk on # of deps          */
     int indep,                     /* consistency chk on # of indeps        */
     int nrows,                     /* # of Jacobian rows being calculated   */
@@ -282,7 +281,7 @@ int int_reverse_safe(
 #endif
 #endif
 {
-  ValueTape &tape = findTape(tnum);
+
   /****************************************************************************/
   /*                                                           ALL VARIABLES  */
   unsigned char operation; /* operation code */
@@ -345,33 +344,34 @@ int int_reverse_safe(
 #define ADOLC_EXT_FCT_POINTER fos_reverse
 #define ADOLC_EXT_FCT_IARR_POINTER fos_reverse_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fos_reverse(edfct->tapeId, m, edfct->dp_U, n, edfct->dp_Z, edfct->dp_x,      \
-              edfct->dp_y)
+  fos_reverse(*edfct->outerTapePtr, m, edfct->dp_U, n, edfct->dp_Z,            \
+              edfct->dp_x, edfct->dp_y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fos_reverse_iArr(edfct->tapeId, iArrLength, iArr, m, edfct->dp_U, n,         \
+  fos_reverse_iArr(*edfct->outerTapePtr, iArrLength, iArr, m, edfct->dp_U, n,  \
                    edfct->dp_Z, edfct->dp_x, edfct->dp_y)
 #define ADOLC_EXT_FCT_SAVE_NUMDIRS
 #define ADOLC_EXT_FCT_V2_U edfct2->up
 #define ADOLC_EXT_FCT_V2_Z edfct2->zp
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fos_reverse(edfct->tapeId, iArrLength, iArr, nout, nin, outsz, edfct2->up,   \
-              insz, edfct2->zp, edfct2->x, edfct2->y, edfct2->context)
+  fos_reverse(*edfct->outerTapePtr, iArrLength, iArr, nout, nin, outsz,        \
+              edfct2->up, insz, edfct2->zp, edfct2->x, edfct2->y,              \
+              edfct2->context)
 #else
 #define ADOLC_EXT_FCT_U edfct->dpp_U
 #define ADOLC_EXT_FCT_Z edfct->dpp_Z
 #define ADOLC_EXT_FCT_POINTER fov_reverse
 #define ADOLC_EXT_FCT_IARR_POINTER fov_reverse_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fov_reverse(edfct->tapeId, m, p, edfct->dpp_U, n, edfct->dpp_Z, edfct->dp_x, \
-              edfct->dp_y)
+  fov_reverse(*edfct->outerTapePtr, m, p, edfct->dpp_U, n, edfct->dpp_Z,       \
+              edfct->dp_x, edfct->dp_y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fov_reverse_iArr(edfct->tapeId, iArrLength, iArr, m, p, edfct->dpp_U, n,     \
-                   edfct->dpp_Z, edfct->dp_x, edfct->dp_y)
+  fov_reverse_iArr(*edfct->outerTapePtr, iArrLength, iArr, m, p, edfct->dpp_U, \
+                   n, edfct->dpp_Z, edfct->dp_x, edfct->dp_y)
 #define ADOLC_EXT_FCT_SAVE_NUMDIRS tape.numDirs_rev(nrows)
 #define ADOLC_EXT_FCT_V2_U edfct2->Up
 #define ADOLC_EXT_FCT_V2_Z edfct2->Zp
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fov_reverse(edfct->tapeId, iArrLength, iArr, nout, nin, outsz, p,            \
+  fov_reverse(*edfct->outerTapePtr, iArrLength, iArr, nout, nin, outsz, p,     \
               edfct2->Up, insz, edfct2->Zp, edfct2->x, edfct2->y,              \
               edfct2->context)
 #endif
@@ -405,7 +405,7 @@ int int_reverse_safe(
   /****************************************************************************/
   /*                                                           DEBUG MESSAGES */
   fprintf(DIAG_OUT, "Call of %s(..) with tag: %d, n: %d, m %d,\n",
-          GENERATED_FILENAME, tnum, indep, depen);
+          GENERATED_FILENAME, tape.tapeId(), indep, depen);
 #ifdef _ADOLC_VECTOR_
   fprintf(DIAG_OUT, "                    p: %d\n\n", nrows);
 #endif
@@ -437,11 +437,11 @@ int int_reverse_safe(
 #if defined(_ABS_NORM_) || defined(_ABS_NORM_SIG_)
   if (!tape.tapestats(TapeInfos::NO_MIN_MAX))
     ADOLCError::fail(ADOLCError::ErrorType::NO_MINMAX, CURRENT_LOCATION,
-                     ADOLCError::FailInfo{.info1 = tnum});
+                     ADOLCError::FailInfo{.info1 = tape.tapeId()});
   else if (to_size_t(swchk) != tape.tapestats(TapeInfos::NUM_SWITCHES))
     ADOLCError::fail(
         ADOLCError::ErrorType::SWITCHES_MISMATCH, CURRENT_LOCATION,
-        ADOLCError::FailInfo{.info1 = tnum,
+        ADOLCError::FailInfo{.info1 = tape.tapeId(),
                              .info3 = swchk,
                              .info6 = tape.tapestats(TapeInfos::NUM_SWITCHES)});
   else
@@ -2596,7 +2596,7 @@ int int_reverse_safe(
       n = tape.get_locint_r();
       tape.ext_diff_fct_index(tape.get_locint_r());
       ADOLC_EXT_FCT_SAVE_NUMDIRS;
-      edfct = get_ext_diff_fct(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct = get_ext_diff_fct(tape, tape.ext_diff_fct_index());
 
       oldTraceFlag = tape.traceFlag();
       tape.traceFlag(0);
@@ -2681,7 +2681,7 @@ int int_reverse_safe(
         iArr[loop - 1] = tape.get_locint_r();
       tape.get_locint_r(); /* get it again */
       ADOLC_EXT_FCT_SAVE_NUMDIRS;
-      edfct = get_ext_diff_fct(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct = get_ext_diff_fct(tape, tape.ext_diff_fct_index());
 
       oldTraceFlag = tape.traceFlag();
       tape.traceFlag(0);
@@ -2777,7 +2777,7 @@ int int_reverse_safe(
       tape.get_locint_r(); /* iArrLength again */
       tape.ext_diff_fct_index(tape.get_locint_r());
       ADOLC_EXT_FCT_SAVE_NUMDIRS;
-      edfct2 = get_ext_diff_fct_v2(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct2 = get_ext_diff_fct_v2(tape, tape.ext_diff_fct_index());
       oldTraceFlag = tape.traceFlag();
       tape.traceFlag(0);
 

--- a/ADOL-C/src/forward_partx.cpp
+++ b/ADOL-C/src/forward_partx.cpp
@@ -22,7 +22,7 @@ BEGIN_C_DECLS
 /* zos_forward_partx(tag, m, mdim[n], n, x[n][d], y[m])                     */
 /* (based on zos_forward)                                                   */
 
-int zos_forward_partx(short tag, int m, int n, const int *ndim,
+int zos_forward_partx(ValueTape &tape, int m, int n, const int *ndim,
                       const double *const *x, double *y) {
   double *x0; /* base point */
   int i, j, ind, sum_n, rc;
@@ -40,7 +40,7 @@ int zos_forward_partx(short tag, int m, int n, const int *ndim,
       ind++;
     }
 
-  rc = zos_forward(tag, m, sum_n, 0, x0, y);
+  rc = zos_forward(tape, m, sum_n, 0, x0, y);
 
   myfree1(x0);
 
@@ -52,7 +52,7 @@ int zos_forward_partx(short tag, int m, int n, const int *ndim,
 /* fos_forward_partx(tag, m, n, ndim[n], x[n][][2], y[m][2])                */
 /* (based on fos_forward)                                                   */
 
-int fos_forward_partx(short tag, int m, int n, const int *ndim,
+int fos_forward_partx(ValueTape &tape, int m, int n, const int *ndim,
                       const double *const *const *x, double **y) {
   double *x0;   /* base point */
   double *xtay; /* Taylor coefficients */
@@ -77,7 +77,7 @@ int fos_forward_partx(short tag, int m, int n, const int *ndim,
       ind++;
     }
 
-  rc = fos_forward(tag, m, sum_n, 0, x0, xtay, y0, ytay);
+  rc = fos_forward(tape, m, sum_n, 0, x0, xtay, y0, ytay);
 
   for (i = 0; i < m; i++) {
     y[i][0] = y0[i];
@@ -97,7 +97,7 @@ int fos_forward_partx(short tag, int m, int n, const int *ndim,
 /* hos_forward_partx(tag, m, n, ndim[n], d, x[n][][d+1], y[m][d+1])         */
 /* (based on hos_forward)                                                   */
 
-int hos_forward_partx(short tag, int m, int n, const int *ndim, int d,
+int hos_forward_partx(ValueTape &tape, int m, int n, const int *ndim, int d,
                       const double *const *const *x, double **y) {
   double *x0;    /* base point */
   double **xtay; /* Taylor coefficients */
@@ -123,7 +123,7 @@ int hos_forward_partx(short tag, int m, int n, const int *ndim, int d,
       ind++;
     }
 
-  rc = hos_forward(tag, m, sum_n, d, 0, x0, xtay, y0, ytay);
+  rc = hos_forward(tape, m, sum_n, d, 0, x0, xtay, y0, ytay);
 
   for (i = 0; i < m; i++) {
     y[i][0] = y0[i];
@@ -145,7 +145,7 @@ int hos_forward_partx(short tag, int m, int n, const int *ndim, int d,
                      y[m], Y[m][p]) */
 /* (based on fov_forward)                                                   */
 
-int fov_forward_partx(short tag, int m, int n, const int *ndim, int p,
+int fov_forward_partx(ValueTape &tape, int m, int n, const int *ndim, int p,
                       const double *const *x, const double *const *const *Xppp,
                       double *y, double **Ypp) {
   double *x0; /* base point */
@@ -168,7 +168,7 @@ int fov_forward_partx(short tag, int m, int n, const int *ndim, int p,
       ind++;
     }
 
-  rc = fov_forward(tag, m, sum_n, p, x0, X, y, Ypp);
+  rc = fov_forward(tape, m, sum_n, p, x0, X, y, Ypp);
 
   myfree1(x0);
   myfree2(X);
@@ -182,8 +182,8 @@ int fov_forward_partx(short tag, int m, int n, const int *ndim, int p,
                      y[m], Y[m][p][d]) */
 /* (based on hov_forward)                                                   */
 
-int hov_forward_partx(short tag, int m, int n, const int *ndim, int d, int p,
-                      const double *const *x,
+int hov_forward_partx(ValueTape &tape, int m, int n, const int *ndim, int d,
+                      int p, const double *const *x,
                       const double *const *const *const *Xpppp, double *y,
                       double ***Yppp) {
   double *x0;  /* base point */
@@ -207,7 +207,7 @@ int hov_forward_partx(short tag, int m, int n, const int *ndim, int d, int p,
       ind++;
     }
 
-  rc = hov_forward(tag, m, sum_n, d, p, x0, X, y, Yppp);
+  rc = hov_forward(tape, m, sum_n, d, p, x0, X, y, Yppp);
 
   myfree1(x0);
   myfree3(X);

--- a/ADOL-C/src/interfaces.cpp
+++ b/ADOL-C/src/interfaces.cpp
@@ -29,8 +29,9 @@
 /****************************************************************************/
 /*                                                             general call */
 /*                                                                          */
-int forward(short tag, int m, int n, int d, int keep, double **X, double **Y)
-/* forward(tag, m, n, d, keep, X[n][d+1], Y[m][d+1])                        */
+int forward(ValueTape &tape, int m, int n, int d, int keep, double **X,
+            double **Y)
+/* forward(tape, m, n, d, keep, X[n][d+1], Y[m][d+1]) */
 { /* olvo 980729 general ec */
   double *x, *y, *xp, *yp;
   int maxn, maxm;
@@ -54,11 +55,11 @@ int forward(short tag, int m, int n, int d, int keep, double **X, double **Y)
   /*------------------------------------------------------------------------*/
   /* function calls */
   if (d == 0)
-    rc = zos_forward(tag, m, n, keep, x, y);
+    rc = zos_forward(tape, m, n, keep, x, y);
   else if (d == 1)
-    rc = fos_forward(tag, m, n, keep, x, xp, y, yp);
+    rc = fos_forward(tape, m, n, keep, x, xp, y, yp);
   else
-    rc = hos_forward(tag, m, n, d, keep, x, X, y, Y);
+    rc = hos_forward(tape, m, n, d, keep, x, X, y, Y);
 
   /*------------------------------------------------------------------------*/
   /* prepare output */
@@ -89,8 +90,9 @@ int forward(short tag, int m, int n, int d, int keep, double **X, double **Y)
 /****************************************************************************/
 /*         Y can be one dimensional if m=1                                  */
 /*                                                                          */
-int forward(short tag, int m, int n, int d, int keep, double **X, double *Y)
-/* forward(tag, 1, n, d, keep, X[n][d+1], Y[d+1]), m=1                      */
+int forward(ValueTape &tape, int m, int n, int d, int keep, double **X,
+            double *Y)
+/* forward(tape, 1, n, d, keep, X[n][d+1], Y[d+1]), m=1 */
 { /* olvo 980729 general ec */
   static double *x, *xp;
   static int maxn;
@@ -121,11 +123,11 @@ int forward(short tag, int m, int n, int d, int keep, double **X, double *Y)
     /*----------------------------------------------------------------------*/
     /* function calls */
     if (d == 0)
-      rc = zos_forward(tag, m, n, keep, x, &y);
+      rc = zos_forward(tape, m, n, keep, x, &y);
     else if (d == 1)
-      rc = fos_forward(tag, m, n, keep, x, xp, &y, Y);
+      rc = fos_forward(tape, m, n, keep, x, xp, &y, Y);
     else
-      rc = hos_forward(tag, m, n, d, keep, x, X, &y, &Y);
+      rc = hos_forward(tape, m, n, d, keep, x, X, &y, &Y);
 
     /*----------------------------------------------------------------------*/
     /* prepare output */
@@ -148,16 +150,16 @@ int forward(short tag, int m, int n, int d, int keep, double **X, double *Y)
 /****************************************************************************/
 /*         X and Y can be one dimensional if d = 0                          */
 /*                                                                          */
-int forward(short tag, int m, int n, int d, int keep, const double *X,
+int forward(ValueTape &tape, int m, int n, int d, int keep, const double *X,
             double *Y)
-/* forward(tag, m, n, 0, keep, X[n], Y[m]), d=0                             */
+/* forward(tape, m, n, 0, keep, X[n], Y[m]), d=0 */
 {
   int rc = -1;
 
   if (d != 0)
     ADOLCError::fail(ADOLCError::ErrorType::WRONG_DIM_XY, CURRENT_LOCATION);
   else
-    rc = zos_forward(tag, m, n, keep, X, Y);
+    rc = zos_forward(tape, m, n, keep, X, Y);
 
   return rc;
 }
@@ -165,30 +167,30 @@ int forward(short tag, int m, int n, int d, int keep, const double *X,
 /****************************************************************************/
 /*         X and Y can be one dimensional if d omitted                      */
 /*                                                                          */
-int forward(short tag, int m, int n, int keep, const double *X, double *Y)
-/* forward(tag, m, n, keep, X[n], Y[m])                                     */
+int forward(ValueTape &tape, int m, int n, int keep, const double *X, double *Y)
+/* forward(tape, m, n, keep, X[n], Y[m]) */
 {
-  return zos_forward(tag, m, n, keep, X, Y);
+  return zos_forward(tape, m, n, keep, X, Y);
 }
 
 /****************************************************************************/
 /*                                                             general call */
 /*                                                                          */
-int forward(short tag, int m, int n, int d, int p, const double *x,
+int forward(ValueTape &tape, int m, int n, int d, int p, const double *x,
             const double *const *const *X, double *y, double ***Y)
-/* forward(tag, m, n, d, p, x[n], X[n][p][d], y[m], Y[m][p][d])             */
+/* forward(tape, m, n, d, p, x[n], X[n][p][d], y[m], Y[m][p][d]) */
 {
-  return hov_forward(tag, m, n, d, p, x, X, y, Y);
+  return hov_forward(tape, m, n, d, p, x, X, y, Y);
 }
 
 /****************************************************************************/
 /*                                                             general call */
 /*                                                                          */
-int forward(short tag, int m, int n, int p, const double *x,
+int forward(ValueTape &tape, int m, int n, int p, const double *x,
             const double *const *X, double *y, double **Y)
-/* forward(tag, m, n, p, x[n], X[n][p], y[m], Y[m][p])                      */
+/* forward(tape, m, n, p, x[n], X[n][p], y[m], Y[m][p]) */
 {
-  return fov_forward(tag, m, n, p, x, X, y, Y);
+  return fov_forward(tape, m, n, p, x, X, y, Y);
 }
 
 /****************************************************************************/
@@ -197,24 +199,24 @@ int forward(short tag, int m, int n, int p, const double *x,
 /****************************************************************************/
 /*                                                             general call */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, const double *u, double **Z)
-/* reverse(tag, m, n, d, u[m], Z[n][d+1])                                   */
+int reverse(ValueTape &tape, int m, int n, int d, const double *u, double **Z)
+/* reverse(tape, m, n, d, u[m], Z[n][d+1]) */
 {
-  return hos_reverse(tag, m, n, d, u, Z);
+  return hos_reverse(tape, m, n, d, u, Z);
 }
 
 /****************************************************************************/
 /*         u can be a scalar if m=1                                         */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, double u, double **Z)
-/* reverse(tag, 1, n, 0, u, Z[n][d+1]), m=1 => u scalar                     */
+int reverse(ValueTape &tape, int m, int n, int d, double u, double **Z)
+/* reverse(tape, 1, n, 0, u, Z[n][d+1]), m=1 => u scalar */
 {
   int rc = -1;
 
   if (m != 1)
     ADOLCError::fail(ADOLCError::ErrorType::WRONG_DIM_u, CURRENT_LOCATION);
   else
-    rc = hos_reverse(tag, m, n, d, &u, Z);
+    rc = hos_reverse(tape, m, n, d, &u, Z);
 
   return rc;
 }
@@ -222,27 +224,27 @@ int reverse(short tag, int m, int n, int d, double u, double **Z)
 /****************************************************************************/
 /*         Z can be vector if d = 0; Done by specialized code               */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, const double *u, double *Z)
-/* reverse(tag, m, n, 0, u[m], Z[n]), d=0                                   */
+int reverse(ValueTape &tape, int m, int n, int d, const double *u, double *Z)
+/* reverse(tape, m, n, 0, u[m], Z[n]), d=0 */
 {
   if (d != 0)
     ADOLCError::fail(ADOLCError::ErrorType::WRONG_DIM_Z, CURRENT_LOCATION);
 
-  return fos_reverse(tag, m, n, u, Z);
+  return fos_reverse(tape, m, n, u, Z);
 }
 
 /****************************************************************************/
 /*         u and Z can be scalars if m=1 and d=0;                           */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, double u, double *Z)
-/* reverse(tag, 1, n, 0, u, Z[n]), m=1 and d=0 => u and Z scalars           */
+int reverse(ValueTape &tape, int m, int n, int d, double u, double *Z)
+/* reverse(tape, 1, n, 0, u, Z[n]), m=1 and d=0 => u and Z scalars */
 {
   int rc = -1;
 
   if (m != 1 || d != 0)
     ADOLCError::fail(ADOLCError::ErrorType::WRONG_DIM_uZ, CURRENT_LOCATION);
   else
-    rc = fos_reverse(tag, m, n, &u, Z);
+    rc = fos_reverse(tape, m, n, &u, Z);
 
   return rc;
 }
@@ -250,19 +252,20 @@ int reverse(short tag, int m, int n, int d, double u, double *Z)
 /****************************************************************************/
 /*                                                             general call */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, int q, const double *const *U,
+int reverse(ValueTape &tape, int m, int n, int d, int q, const double *const *U,
             double ***Z, short **nz)
-/* reverse(tag, m, n, d, q, U[q][m], Z[q][n][d+1], nz[q][n])                */
+/* reverse(tape, m, n, d, q, U[q][m], Z[q][n][d+1], nz[q][n]) */
 {
-  return hov_reverse(tag, m, n, d, q, U, Z, nz);
+  return hov_reverse(tape, m, n, d, q, U, Z, nz);
 }
 
 /****************************************************************************/
 /*         U can be a vector if m=1                                         */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, int q, double *U, double ***Z,
+int reverse(ValueTape &tape, int m, int n, int d, int q, double *U, double ***Z,
             short **nz)
-/* reverse(tag, 1, n, d, q, U[q], Z[q][n][d+1], nz[q][n]), m=1 => u vector  */
+/* reverse(tape, 1, n, d, q, U[q], Z[q][n][d+1], nz[q][n]), m=1 => u vector
+ */
 {
   int rc = -1;
 
@@ -274,7 +277,7 @@ int reverse(short tag, int m, int n, int d, int q, double *U, double ***Z,
     double **upp = (double **)malloc(q * sizeof(double *));
     for (int i = 0; i < q; i++)
       upp[i] = &U[i];
-    rc = hov_reverse(tag, m, n, d, q, upp, Z, nz);
+    rc = hov_reverse(tape, m, n, d, q, upp, Z, nz);
     /* delete[] upp; */
     free((char *)upp);
   }
@@ -285,16 +288,16 @@ int reverse(short tag, int m, int n, int d, int q, double *U, double ***Z,
 /*                                                                          */
 /*         If d=0 then Z may be matrix; Done by specialized code            */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, int q, const double *const *U,
+int reverse(ValueTape &tape, int m, int n, int d, int q, const double *const *U,
             double **Z)
-/* reverse(tag, m, n, 0, q, U[q][m], Z[q][n]), d=0 => Z matrix              */
+/* reverse(tape, m, n, 0, q, U[q][m], Z[q][n]), d=0 => Z matrix */
 {
   int rc = -1;
 
   if (d != 0)
     ADOLCError::fail(ADOLCError::ErrorType::WRONG_DIM_D, CURRENT_LOCATION);
   else
-    rc = fov_reverse(tag, m, n, q, U, Z);
+    rc = fov_reverse(tape, m, n, q, U, Z);
 
   return rc;
 }
@@ -303,12 +306,13 @@ int reverse(short tag, int m, int n, int d, int q, const double *const *U,
 /*                                                                          */
 /*         d=0 may be omitted, then Z may be a matrix; specialized code     */
 /*                                                                          */
-int reverse(short tag, int m, int n, int q, const double *const *U, double **Z)
-/* reverse(tag, m, n, q, U[q][m], Z[q][n]), d=0 => Z matrix                 */
+int reverse(ValueTape &tape, int m, int n, int q, const double *const *U,
+            double **Z)
+/* reverse(tape, m, n, q, U[q][m], Z[q][n]), d=0 => Z matrix */
 {
   int rc = -1;
 
-  rc = fov_reverse(tag, m, n, q, U, Z);
+  rc = fov_reverse(tape, m, n, q, U, Z);
 
   return rc;
 }
@@ -317,8 +321,8 @@ int reverse(short tag, int m, int n, int q, const double *const *U, double **Z)
 /*                                                                          */
 /*         If m=1 and d=0 then U can be vector and Z a matrix but no nz.    */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, int q, double *U, double **Z)
-/* reverse(tag, 1, n, 0, q, U[q], Z[q][n]),
+int reverse(ValueTape &tape, int m, int n, int d, int q, double *U, double **Z)
+/* reverse(tape, 1, n, 0, q, U[q], Z[q][n]),
                             m=1 and d=0 => U vector and Z matrix but no nz  */
 {
   int rc = -1;
@@ -333,7 +337,7 @@ int reverse(short tag, int m, int n, int d, int q, double *U, double **Z)
     double **upp = (double **)malloc(q * sizeof(double *));
     for (int i = 0; i < q; i++)
       upp[i] = &U[i];
-    rc = fov_reverse(tag, m, n, q, upp, Z);
+    rc = fov_reverse(tape, m, n, q, upp, Z);
     /* delete[] upp; */
     free((char *)upp);
   }
@@ -345,8 +349,8 @@ int reverse(short tag, int m, int n, int d, int q, double *U, double **Z)
 /*                                                                          */
 /*         If p and U are omitted they default to m and I so that as above  */
 /*                                                                          */
-int reverse(short tag, int m, int n, int d, double ***Z, short **nz)
-/* reverse(tag, m, n, d, Z[p][n][d+1], nz[p][n]),
+int reverse(ValueTape &tape, int m, int n, int d, double ***Z, short **nz)
+/* reverse(tape, m, n, d, Z[p][n][d+1], nz[p][n]),
            If p and U are omitted they default to m and I                   */
 {
   static int depax;
@@ -356,7 +360,7 @@ int reverse(short tag, int m, int n, int d, double ***Z, short **nz)
       myfreeI2(depax, I);
     I = myallocI2(depax = m);
   }
-  return hov_reverse(tag, m, n, d, m, I, Z, nz);
+  return hov_reverse(tape, m, n, d, m, I, Z, nz);
 }
 
 /****************************************************************************/

--- a/ADOL-C/src/interfacesf.cpp
+++ b/ADOL-C/src/interfacesf.cpp
@@ -21,11 +21,10 @@
 BEGIN_C_DECLS
 
 /*--------------------------------------------------------------------------*/
-fint hos_forward_(const fint *ftag, const fint *fm, const fint *fn,
+fint hos_forward_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fd, const fint *fk, const fdouble *fbase,
                   const fdouble *fx, fdouble *fvalue, fdouble *fy) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd), k = static_cast<int>(*fk);
   double *base = myalloc1(n);
@@ -34,7 +33,7 @@ fint hos_forward_(const fint *ftag, const fint *fm, const fint *fn,
   double **Y = myalloc2(m, d);
   spread1(n, fbase, base);
   spread2(n, d, fx, X);
-  rc = hos_forward(tag, m, n, d, k, base, X, value, Y);
+  rc = hos_forward(tape, m, n, d, k, base, X, value, Y);
   pack2(m, d, Y, fy);
   pack1(m, value, fvalue);
   myfree2(X);
@@ -45,16 +44,15 @@ fint hos_forward_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint zos_forward_(const fint *ftag, const fint *fm, const fint *fn,
+fint zos_forward_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fk, const fdouble *fbase, fdouble *fvalue) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       k = static_cast<int>(*fk);
   double *base = myalloc1(n);
   double *value = myalloc1(m);
   spread1(n, fbase, base);
-  rc = zos_forward(tag, m, n, k, base, value);
+  rc = zos_forward(tape, m, n, k, base, value);
   pack1(m, value, fvalue);
   myfree1(base);
   myfree1(value);
@@ -62,11 +60,10 @@ fint zos_forward_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint hov_forward_(const fint *ftag, const fint *fm, const fint *fn,
+fint hov_forward_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fd, const fint *fp, const fdouble *fbase,
                   const fdouble *fx, fdouble *fvalue, fdouble *fy) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd), p = static_cast<int>(*fp);
   double *base = myalloc1(n);
@@ -75,7 +72,7 @@ fint hov_forward_(const fint *ftag, const fint *fm, const fint *fn,
   double ***Y = myalloc3(m, p, d);
   spread1(n, fbase, base);
   spread3(n, p, d, fx, X);
-  rc = hov_forward(tag, m, n, d, p, base, X, value, Y);
+  rc = hov_forward(tape, m, n, d, p, base, X, value, Y);
   pack3(m, p, d, Y, fy);
   pack1(m, value, fvalue);
   myfree3(X);
@@ -86,11 +83,10 @@ fint hov_forward_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint fov_forward_(const fint *ftag, const fint *fm, const fint *fn,
+fint fov_forward_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fp, const fdouble *fbase, const fdouble *fx,
                   fdouble *fvalue, fdouble *fy) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       p = static_cast<int>(*fp);
   double *base = myalloc1(n);
@@ -99,7 +95,7 @@ fint fov_forward_(const fint *ftag, const fint *fm, const fint *fn,
   double **Y = myalloc2(m, p);
   spread1(n, fbase, base);
   spread2(n, p, fx, X);
-  rc = fov_forward(tag, m, n, p, base, X, value, Y);
+  rc = fov_forward(tape, m, n, p, base, X, value, Y);
   pack2(m, p, Y, fy);
   pack1(m, value, fvalue);
   myfree2(X);
@@ -110,16 +106,15 @@ fint fov_forward_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint hos_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint hos_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fd, const fdouble *fu, fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd);
   double **Z = myalloc2(n, d + 1);
   double *u = myalloc1(m);
   spread1(m, fu, u);
-  rc = hos_reverse(tag, m, n, d, u, Z);
+  rc = hos_reverse(tape, m, n, d, u, Z);
   pack2(n, d + 1, Z, fz);
   myfree2(Z);
   myfree1(u);
@@ -127,16 +122,15 @@ fint hos_reverse_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint hos_ti_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint hos_ti_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                      const fint *fd, const fdouble *fu, fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd);
   double **Z = myalloc2(n, d + 1);
   double **U = myalloc2(m, d + 1);
   spread2(m, d + 1, fu, U);
-  rc = hos_ti_reverse(tag, m, n, d, U, Z);
+  rc = hos_ti_reverse(tape, m, n, d, U, Z);
   pack2(n, d + 1, Z, fz);
   myfree2(Z);
   myfree2(U);
@@ -144,15 +138,14 @@ fint hos_ti_reverse_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint fos_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint fos_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fdouble *fu, fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn);
   double *u = myalloc1(m);
   double *Z = myalloc1(n);
   spread1(m, fu, u);
-  rc = fos_reverse(tag, m, n, u, Z);
+  rc = fos_reverse(tape, m, n, u, Z);
   pack1(n, Z, fz);
   myfree1(Z);
   myfree1(u);
@@ -160,18 +153,17 @@ fint fos_reverse_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint hov_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint hov_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fd, const fint *fq, const fdouble *fu,
                   fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd), q = static_cast<int>(*fq);
   double **U = myalloc2(q, m);
   double ***Z = myalloc3(q, n, d + 1);
   short **nop = 0;
   spread2(q, m, fu, U);
-  rc = hov_reverse(tag, m, n, d, q, U, Z, nop);
+  rc = hov_reverse(tape, m, n, d, q, U, Z, nop);
   pack3(q, n, d + 1, Z, fz);
   myfree3(Z);
   myfree2(U);
@@ -179,18 +171,17 @@ fint hov_reverse_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint hov_ti_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint hov_ti_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                      const fint *fd, const fint *fq, const fdouble *fu,
                      fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       d = static_cast<int>(*fd), q = static_cast<int>(*fq);
   double ***U = myalloc3(q, m, d + 1);
   double ***Z = myalloc3(q, n, d + 1);
   short **nop = 0;
   spread3(q, m, d + 1, fu, U);
-  rc = hov_ti_reverse(tag, m, n, d, q, U, Z, nop);
+  rc = hov_ti_reverse(tape, m, n, d, q, U, Z, nop);
   pack3(q, n, d + 1, Z, fz);
   myfree3(Z);
   myfree3(U);
@@ -198,16 +189,15 @@ fint hov_ti_reverse_(const fint *ftag, const fint *fm, const fint *fn,
 }
 
 /*--------------------------------------------------------------------------*/
-fint fov_reverse_(const fint *ftag, const fint *fm, const fint *fn,
+fint fov_reverse_(ValueTape &tape, const fint *fm, const fint *fn,
                   const fint *fq, const fdouble *fu, fdouble *fz) {
   int rc = -1;
-  short tag = static_cast<short>(*ftag);
   int m = static_cast<int>(*fm), n = static_cast<int>(*fn),
       q = static_cast<int>(*fq);
   double **U = myalloc2(q, m);
   double **Z = myalloc2(q, n);
   spread2(q, m, fu, U);
-  rc = fov_reverse(tag, m, n, q, U, Z);
+  rc = fov_reverse(tape, m, n, q, U, Z);
   pack2(q, n, Z, fz);
   myfree2(Z);
   myfree2(U);

--- a/ADOL-C/src/lie/adolc_lie.cpp
+++ b/ADOL-C/src/lie/adolc_lie.cpp
@@ -15,22 +15,22 @@
 #include <adolc/adolc.h>
 #include <adolc/lie/drivers.h>
 
-int lie_scalar(short Tape_F, short Tape_H, short n, short m, double *x0,
-               short d, double **result) {
-  return lie_scalarcv(Tape_F, Tape_H, n, m, x0, d, result);
+int lie_scalar(ValueTape &tape_F, ValueTape &tape_H, short n, short m,
+               double *x0, short d, double **result) {
+  return lie_scalarcv(tape_F, tape_H, n, m, x0, d, result);
 }
 
-int lie_scalar(short Tape_F, short Tape_H, short n, double *x0, short d,
-               double *result) {
-  return lie_scalarc(Tape_F, Tape_H, n, x0, d, result);
+int lie_scalar(ValueTape &tape_F, ValueTape &tape_H, short n, double *x0,
+               short d, double *result) {
+  return lie_scalarc(tape_F, tape_H, n, x0, d, result);
 }
 
-int lie_gradient(short int Tape_F, short int Tape_H, short int n, short int m,
+int lie_gradient(ValueTape &tape_F, ValueTape &tape_H, short int n, short int m,
                  double *x0, short int d, double ***result) {
-  return lie_gradientcv(Tape_F, Tape_H, n, m, x0, d, result);
+  return lie_gradientcv(tape_F, tape_H, n, m, x0, d, result);
 }
 
-int lie_gradient(short int Tape_F, short int Tape_H, short int n, double *x0,
+int lie_gradient(ValueTape &tape_F, ValueTape &tape_H, short int n, double *x0,
                  short int d, double **result) {
-  return lie_gradientc(Tape_F, Tape_H, n, x0, d, result);
+  return lie_gradientc(tape_F, tape_H, n, x0, d, result);
 }

--- a/ADOL-C/src/pdouble.cpp
+++ b/ADOL-C/src/pdouble.cpp
@@ -22,7 +22,7 @@
 pdouble::pdouble(const double pval) { value(pval); }
 
 pdouble::operator adouble() const {
-  ValueTape &tape = currentTape();
+  auto &tape = *currentTapePtr();
   adouble ret_adouble;
   if (tape.traceFlag()) {
     tape.put_op(assign_p);

--- a/ADOL-C/src/revolve.cpp
+++ b/ADOL-C/src/revolve.cpp
@@ -295,7 +295,6 @@ enum revolve_action revolve(int *check, int *capo, int *fine, int snaps,
   int ds, oldcapo, num, bino1, bino2, bino3, bino4, bino5, bino6;
   /* (*capo,*fine) is the time range currently under consideration */
   /* ch[j] is the number of the state that is stored in checkpoint j */
-  rev_num = get_revolve_numbers();
   rev_num.commands += 1;
   if ((*check < -1) || (*capo > *fine)) {
     *info = 9;

--- a/ADOL-C/src/uni5_for.cpp
+++ b/ADOL-C/src/uni5_for.cpp
@@ -32,14 +32,13 @@ and _NTIGHT__
 #include <adolc/adalloc.h>
 #include <adolc/adolcerror.h>
 #include <adolc/dvlparms.h>
-#include <cmath>
 #include <adolc/externfcts.h>
 #include <adolc/interfaces.h>
 #include <adolc/internal/common.h>
 #include <adolc/oplate.h>
 #include <adolc/tape_interface.h>
 #include <adolc/valuetape/valuetape.h>
-
+#include <cmath>
 
 #if defined(ADOLC_DEBUG) || defined(_ZOS_)
 #include <string.h>
@@ -500,7 +499,7 @@ BEGIN_C_DECLS
 /* Zero Order Scalar version of the forward mode.                           */
 /****************************************************************************/
 #if defined(_ABS_NORM_)
-int zos_pl_forward(ValueTape& tape, int depcheck, int indcheck, int keep,
+int zos_pl_forward(ValueTape &tape, int depcheck, int indcheck, int keep,
                    const double *basepoint, double *valuepoint, double *swargs)
 #else
 #if defined(_KEEP_)
@@ -508,9 +507,9 @@ int zos_forward(
 #else
 int zos_forward_nk(
 #endif
-    ValueTape& tape,   /* tape id */
-    int depcheck, /* consistency chk on # of deps */
-    int indcheck, /* consistency chk on # of indeps */
+    ValueTape &tape, /* tape id */
+    int depcheck,    /* consistency chk on # of deps */
+    int indcheck,    /* consistency chk on # of indeps */
 #if defined(_KEEP_)
     int keep, /* flag for reverse sweep */
 #endif
@@ -525,12 +524,12 @@ int zos_forward_nk(
 /* First Order Scalar version of the forward mode. */
 /****************************************************************************/
 #if defined(_ABS_NORM_)
-int fos_pl_forward(ValueTape& tape, int depcheck, int indcheck,
+int fos_pl_forward(ValueTape &tape, int depcheck, int indcheck,
                    const double *basepoint, const double *argument,
                    double *valuepoint, double *taylors, double *swargs,
                    double *swtaylors)
 #elif defined(_ABS_NORM_SIG_)
-int fos_pl_sig_forward(ValueTape& tape, int depcheck, int indcheck,
+int fos_pl_sig_forward(ValueTape &tape, int depcheck, int indcheck,
                        const double *basepoint, const double *argument,
                        int swcheck, const short *sigbase, const short *sigdir,
                        double *valuepoint, double *taylors, double *swargs,
@@ -541,9 +540,9 @@ int fos_forward(
 #else
 int fos_forward_nk(
 #endif
-    ValueTape& tape,   /* tape id */
-    int depcheck, /* consistency chk on # of deps */
-    int indcheck, /* consistency chk on # of indeps */
+    ValueTape &tape, /* tape id */
+    int depcheck,    /* consistency chk on # of deps */
+    int indcheck,    /* consistency chk on # of indeps */
 #if defined(_KEEP_)
     int keep, /* flag for reverse sweep */
 #endif
@@ -561,7 +560,7 @@ int fos_forward_nk(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int int_forward_tight(
-    ValueTape& tape,                    /* tape id                              */
+    ValueTape &tape,               /* tape id                              */
     int depcheck,                  /* consistency chk on # of dependents   */
     int indcheck,                  /* consistency chk on # of independents */
     int p,                         /* # of taylor series, bit pattern      */
@@ -588,10 +587,10 @@ int int_forward_tight(
 /****************************************************************************/
 /* First Order Vector version of the forward mode, bit pattern, safe        */
 /****************************************************************************/
-int int_forward_safe(ValueTape& tape,   /* tape id                              */
-                     int depcheck, /* consistency chk on # of dependents   */
-                     int indcheck, /* consistency chk on # of independents */
-                     int p,        /* # of taylor series, bit pattern      */
+int int_forward_safe(ValueTape &tape, /* tape id                              */
+                     int depcheck,    /* consistency chk on # of dependents   */
+                     int indcheck,    /* consistency chk on # of independents */
+                     int p,           /* # of taylor series, bit pattern      */
                      const size_t *const *argument, /* Taylor coeff. (in)*/
                      size_t **taylors) /* matrix of coefficient vectors (out)*/
 
@@ -615,7 +614,7 @@ and pass a bit pattern version of the identity matrix as an argument    */
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int indopro_forward_tight(
-    ValueTape& tape,              /* tape id                              */
+    ValueTape &tape,         /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -628,7 +627,7 @@ int indopro_forward_tight(
 #if defined(_NTIGHT_)
 #if defined(_ABS_NORM_)
     int indopro_forward_absnormal(
-        ValueTape& tape,         /* tape id                              */
+        ValueTape &tape,    /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         int swcheck,        /* consistency chk on # of switches    */
@@ -642,7 +641,7 @@ int indopro_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int indopro_forward_safe(
-        ValueTape& tape,         /* tape id                              */
+        ValueTape &tape,    /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -660,7 +659,7 @@ int indopro_forward_tight(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int nonl_ind_forward_tight(
-    ValueTape& tape,              /* tape id                              */
+    ValueTape &tape,         /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -672,7 +671,7 @@ int nonl_ind_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int nonl_ind_forward_safe(
-        ValueTape& tape,         /* tape id                              */
+        ValueTape &tape,    /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -689,7 +688,7 @@ int nonl_ind_forward_tight(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int nonl_ind_old_forward_tight(
-    ValueTape& tape,              /* tape id                              */
+    ValueTape &tape,         /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -701,7 +700,7 @@ int nonl_ind_old_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int nonl_ind_old_forward_safe(
-        ValueTape& tape,         /* tape id                              */
+        ValueTape &tape,    /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -719,7 +718,7 @@ int nonl_ind_old_forward_tight(
 /* **argument and **taylors                                                 */
 /****************************************************************************/
 int fov_offset_forward(
-    ValueTape& tape,                    /* tape id */
+    ValueTape &tape,               /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -736,7 +735,7 @@ int fov_offset_forward(
 /****************************************************************************/
 #if defined(_ABS_NORM_)
 int fov_pl_forward(
-    ValueTape& tape,                    /* tape id */
+    ValueTape &tape,               /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -749,7 +748,7 @@ int fov_pl_forward(
  * [var][taylor] */
 #elif defined(_ABS_NORM_SIG_)
 int fov_pl_sig_forward(
-    ValueTape& tape,                    /* tape id */
+    ValueTape &tape,               /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -762,7 +761,7 @@ int fov_pl_sig_forward(
     double **taylors,              /* matrix of coifficient vectors */
     double *swargs, double **swtaylors, short *sigsw)
 #else
-int fov_forward(ValueTape& tape,              /* tape id */
+int fov_forward(ValueTape &tape,         /* tape id */
                 int depcheck,            /* consistency chk on # of deps */
                 int indcheck,            /* consistency chk on # of indeps */
                 int p,                   /* # of taylor series */
@@ -785,10 +784,10 @@ int hos_forward(
 #else
 int hos_forward_nk(
 #endif
-    ValueTape& tape,   /* tape id */
-    int depcheck, /* consistency chk on # of dependents */
-    int indcheck, /* consistency chk on # of independents */
-    int gdegree,  /* highest derivative degree */
+    ValueTape &tape, /* tape id */
+    int depcheck,    /* consistency chk on # of dependents */
+    int indcheck,    /* consistency chk on # of independents */
+    int gdegree,     /* highest derivative degree */
 #if defined(_KEEP_)
     int keep, /* flag for reverse sweep */
 #endif
@@ -806,10 +805,10 @@ int hov_wk_forward(
 #else
 int hov_forward(
 #endif
-    ValueTape& tape,   /* tape id */
-    int depcheck, /* consistency chk on # of deps */
-    int indcheck, /* consistency chk on # of indeps */
-    int gdegree,  /* highest derivative degree */
+    ValueTape &tape, /* tape id */
+    int depcheck,    /* consistency chk on # of deps */
+    int indcheck,    /* consistency chk on # of indeps */
+    int gdegree,     /* highest derivative degree */
 #if defined(_KEEP_)
     int keep, /* flag for reverse sweep */
 #endif
@@ -971,11 +970,11 @@ int hov_forward(
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
   zos_forward(*edfct->outerTapePtr, n, edfct->dp_x, m, edfct->dp_y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  zos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, m,         \
+  zos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, m,  \
                    edfct->dp_y)
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  zos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
-              outsz, edfct2->y, edfct2->context)
+  zos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz,         \
+              edfct2->x, outsz, edfct2->y, edfct2->context)
 #define ADOLC_EXT_COPY_TAYLORS(dest, src)
 #endif
   /* FOS_FORWARD */
@@ -984,16 +983,17 @@ int hov_forward(
 #define ADOLC_EXT_FCT_POINTER fos_forward
 #define ADOLC_EXT_FCT_IARR_POINTER fos_forward_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fos_forward(*edfct->outerTapePtr, n, edfct->dp_x, edfct->dp_X, m, edfct->dp_y,      \
-              edfct->dp_Y)
+  fos_forward(*edfct->outerTapePtr, n, edfct->dp_x, edfct->dp_X, m,            \
+              edfct->dp_y, edfct->dp_Y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x,            \
+  fos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x,     \
                    edfct->dp_X, m, edfct->dp_y, edfct->dp_Y)
 #define ADOLC_EXT_POINTER_X edfct->dp_X
 #define ADOLC_EXT_POINTER_Y edfct->dp_Y
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
-              edfct2->xp, outsz, edfct2->y, edfct2->yp, edfct2->context)
+  fos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz,         \
+              edfct2->x, edfct2->xp, outsz, edfct2->y, edfct2->yp,             \
+              edfct2->context)
 #define ADOLC_EXT_V2_POINTER_X edfct2->xp
 #define ADOLC_EXT_V2_POINTER_Y edfct2->yp
 #define ADOLC_EXT_COPY_TAYLORS(dest, src) dest = src
@@ -1005,16 +1005,17 @@ int hov_forward(
 #define ADOLC_EXT_FCT_POINTER fov_forward
 #define ADOLC_EXT_FCT_IARR_POINTER fov_forward_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fov_forward(*edfct->outerTapePtr, n, edfct->dp_x, p, edfct->dpp_X, m, edfct->dp_y,  \
-              edfct->dpp_Y)
+  fov_forward(*edfct->outerTapePtr, n, edfct->dp_x, p, edfct->dpp_X, m,        \
+              edfct->dp_y, edfct->dpp_Y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fov_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, p,         \
+  fov_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, p,  \
                    edfct->dpp_X, m, edfct->dp_y, edfct->dpp_Y)
 #define ADOLC_EXT_POINTER_X edfct->dpp_X
 #define ADOLC_EXT_POINTER_Y edfct->dpp_Y
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fov_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x, p,  \
-              edfct2->Xp, outsz, edfct2->y, edfct2->Yp, edfct2->context)
+  fov_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz,         \
+              edfct2->x, p, edfct2->Xp, outsz, edfct2->y, edfct2->Yp,          \
+              edfct2->context)
 #define ADOLC_EXT_V2_POINTER_X edfct2->Xp
 #define ADOLC_EXT_V2_POINTER_Y edfct2->Yp
 #define ADOLC_EXT_COPY_TAYLORS(dest, src) dest = src
@@ -5975,7 +5976,7 @@ int hov_forward(
 
 /****************************************************************************/
 #if defined(_ZOS_) && defined(_ABS_NORM_)
-size_t get_num_switches(ValueTape& tape) {
+size_t get_num_switches(ValueTape &tape) {
   tape.init_for_sweep();
   if (!tape.tapestats(TapeInfos::NO_MIN_MAX))
     ADOLCError::fail(ADOLCError::ErrorType::NO_MINMAX, CURRENT_LOCATION,

--- a/ADOL-C/src/uni5_for.cpp
+++ b/ADOL-C/src/uni5_for.cpp
@@ -32,14 +32,14 @@ and _NTIGHT__
 #include <adolc/adalloc.h>
 #include <adolc/adolcerror.h>
 #include <adolc/dvlparms.h>
+#include <cmath>
 #include <adolc/externfcts.h>
 #include <adolc/interfaces.h>
 #include <adolc/internal/common.h>
 #include <adolc/oplate.h>
 #include <adolc/tape_interface.h>
 #include <adolc/valuetape/valuetape.h>
-#include <math.h>
-#include <string.h>
+
 
 #if defined(ADOLC_DEBUG) || defined(_ZOS_)
 #include <string.h>
@@ -500,7 +500,7 @@ BEGIN_C_DECLS
 /* Zero Order Scalar version of the forward mode.                           */
 /****************************************************************************/
 #if defined(_ABS_NORM_)
-int zos_pl_forward(short tnum, int depcheck, int indcheck, int keep,
+int zos_pl_forward(ValueTape& tape, int depcheck, int indcheck, int keep,
                    const double *basepoint, double *valuepoint, double *swargs)
 #else
 #if defined(_KEEP_)
@@ -508,7 +508,7 @@ int zos_forward(
 #else
 int zos_forward_nk(
 #endif
-    short tnum,   /* tape id */
+    ValueTape& tape,   /* tape id */
     int depcheck, /* consistency chk on # of deps */
     int indcheck, /* consistency chk on # of indeps */
 #if defined(_KEEP_)
@@ -525,12 +525,12 @@ int zos_forward_nk(
 /* First Order Scalar version of the forward mode. */
 /****************************************************************************/
 #if defined(_ABS_NORM_)
-int fos_pl_forward(short tnum, int depcheck, int indcheck,
+int fos_pl_forward(ValueTape& tape, int depcheck, int indcheck,
                    const double *basepoint, const double *argument,
                    double *valuepoint, double *taylors, double *swargs,
                    double *swtaylors)
 #elif defined(_ABS_NORM_SIG_)
-int fos_pl_sig_forward(short tnum, int depcheck, int indcheck,
+int fos_pl_sig_forward(ValueTape& tape, int depcheck, int indcheck,
                        const double *basepoint, const double *argument,
                        int swcheck, const short *sigbase, const short *sigdir,
                        double *valuepoint, double *taylors, double *swargs,
@@ -541,7 +541,7 @@ int fos_forward(
 #else
 int fos_forward_nk(
 #endif
-    short tnum,   /* tape id */
+    ValueTape& tape,   /* tape id */
     int depcheck, /* consistency chk on # of deps */
     int indcheck, /* consistency chk on # of indeps */
 #if defined(_KEEP_)
@@ -561,7 +561,7 @@ int fos_forward_nk(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int int_forward_tight(
-    short tnum,                    /* tape id                              */
+    ValueTape& tape,                    /* tape id                              */
     int depcheck,                  /* consistency chk on # of dependents   */
     int indcheck,                  /* consistency chk on # of independents */
     int p,                         /* # of taylor series, bit pattern      */
@@ -588,7 +588,7 @@ int int_forward_tight(
 /****************************************************************************/
 /* First Order Vector version of the forward mode, bit pattern, safe        */
 /****************************************************************************/
-int int_forward_safe(short tnum,   /* tape id                              */
+int int_forward_safe(ValueTape& tape,   /* tape id                              */
                      int depcheck, /* consistency chk on # of dependents   */
                      int indcheck, /* consistency chk on # of independents */
                      int p,        /* # of taylor series, bit pattern      */
@@ -615,7 +615,7 @@ and pass a bit pattern version of the identity matrix as an argument    */
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int indopro_forward_tight(
-    short tnum,              /* tape id                              */
+    ValueTape& tape,              /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -628,7 +628,7 @@ int indopro_forward_tight(
 #if defined(_NTIGHT_)
 #if defined(_ABS_NORM_)
     int indopro_forward_absnormal(
-        short tnum,         /* tape id                              */
+        ValueTape& tape,         /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         int swcheck,        /* consistency chk on # of switches    */
@@ -642,7 +642,7 @@ int indopro_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int indopro_forward_safe(
-        short tnum,         /* tape id                              */
+        ValueTape& tape,         /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -660,7 +660,7 @@ int indopro_forward_tight(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int nonl_ind_forward_tight(
-    short tnum,              /* tape id                              */
+    ValueTape& tape,              /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -672,7 +672,7 @@ int nonl_ind_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int nonl_ind_forward_safe(
-        short tnum,         /* tape id                              */
+        ValueTape& tape,         /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -689,7 +689,7 @@ int nonl_ind_forward_tight(
 /* First Order Vector version of the forward mode for bit patterns, tight   */
 /****************************************************************************/
 int nonl_ind_old_forward_tight(
-    short tnum,              /* tape id                              */
+    ValueTape& tape,              /* tape id                              */
     int depcheck,            /* consistency chk on # of dependents   */
     int indcheck,            /* consistency chk on # of independents */
     const double *basepoint, /* independent variable values   (in)   */
@@ -701,7 +701,7 @@ int nonl_ind_old_forward_tight(
     /* First Order Vector version of the forward mode, bit pattern, safe */
     /****************************************************************************/
     int nonl_ind_old_forward_safe(
-        short tnum,         /* tape id                              */
+        ValueTape& tape,         /* tape id                              */
         int depcheck,       /* consistency chk on # of dependents   */
         int indcheck,       /* consistency chk on # of independents */
         const double *,     /* independent variable values   (in)   */
@@ -719,7 +719,7 @@ int nonl_ind_old_forward_tight(
 /* **argument and **taylors                                                 */
 /****************************************************************************/
 int fov_offset_forward(
-    short tnum,                    /* tape id */
+    ValueTape& tape,                    /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -736,7 +736,7 @@ int fov_offset_forward(
 /****************************************************************************/
 #if defined(_ABS_NORM_)
 int fov_pl_forward(
-    short tnum,                    /* tape id */
+    ValueTape& tape,                    /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -749,7 +749,7 @@ int fov_pl_forward(
  * [var][taylor] */
 #elif defined(_ABS_NORM_SIG_)
 int fov_pl_sig_forward(
-    short tnum,                    /* tape id */
+    ValueTape& tape,                    /* tape id */
     int depcheck,                  /* consistency chk on # of deps */
     int indcheck,                  /* consistency chk on # of indeps */
     int p,                         /* # of taylor series */
@@ -762,7 +762,7 @@ int fov_pl_sig_forward(
     double **taylors,              /* matrix of coifficient vectors */
     double *swargs, double **swtaylors, short *sigsw)
 #else
-int fov_forward(short tnum,              /* tape id */
+int fov_forward(ValueTape& tape,              /* tape id */
                 int depcheck,            /* consistency chk on # of deps */
                 int indcheck,            /* consistency chk on # of indeps */
                 int p,                   /* # of taylor series */
@@ -785,7 +785,7 @@ int hos_forward(
 #else
 int hos_forward_nk(
 #endif
-    short tnum,   /* tape id */
+    ValueTape& tape,   /* tape id */
     int depcheck, /* consistency chk on # of dependents */
     int indcheck, /* consistency chk on # of independents */
     int gdegree,  /* highest derivative degree */
@@ -806,7 +806,7 @@ int hov_wk_forward(
 #else
 int hov_forward(
 #endif
-    short tnum,   /* tape id */
+    ValueTape& tape,   /* tape id */
     int depcheck, /* consistency chk on # of deps */
     int indcheck, /* consistency chk on # of indeps */
     int gdegree,  /* highest derivative degree */
@@ -830,7 +830,6 @@ int hov_forward(
 #endif
 #endif
 {
-  ValueTape &tape = findTape(tnum);
   /****************************************************************************/
   /*                                                            ALL VARIABLES */
 
@@ -970,12 +969,12 @@ int hov_forward(
 #define ADOLC_EXT_FCT_POINTER zos_forward
 #define ADOLC_EXT_FCT_IARR_POINTER zos_forward_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  zos_forward(edfct->tapeId, n, edfct->dp_x, m, edfct->dp_y)
+  zos_forward(*edfct->outerTapePtr, n, edfct->dp_x, m, edfct->dp_y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  zos_forward_iArr(edfct->tapeId, iArrLength, iArr, n, edfct->dp_x, m,         \
+  zos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, m,         \
                    edfct->dp_y)
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  zos_forward(edfct->tapeId, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
+  zos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
               outsz, edfct2->y, edfct2->context)
 #define ADOLC_EXT_COPY_TAYLORS(dest, src)
 #endif
@@ -985,15 +984,15 @@ int hov_forward(
 #define ADOLC_EXT_FCT_POINTER fos_forward
 #define ADOLC_EXT_FCT_IARR_POINTER fos_forward_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fos_forward(edfct->tapeId, n, edfct->dp_x, edfct->dp_X, m, edfct->dp_y,      \
+  fos_forward(*edfct->outerTapePtr, n, edfct->dp_x, edfct->dp_X, m, edfct->dp_y,      \
               edfct->dp_Y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fos_forward_iArr(edfct->tapeId, iArrLength, iArr, n, edfct->dp_x,            \
+  fos_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x,            \
                    edfct->dp_X, m, edfct->dp_y, edfct->dp_Y)
 #define ADOLC_EXT_POINTER_X edfct->dp_X
 #define ADOLC_EXT_POINTER_Y edfct->dp_Y
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fos_forward(edfct->tapeId, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
+  fos_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x,     \
               edfct2->xp, outsz, edfct2->y, edfct2->yp, edfct2->context)
 #define ADOLC_EXT_V2_POINTER_X edfct2->xp
 #define ADOLC_EXT_V2_POINTER_Y edfct2->yp
@@ -1006,15 +1005,15 @@ int hov_forward(
 #define ADOLC_EXT_FCT_POINTER fov_forward
 #define ADOLC_EXT_FCT_IARR_POINTER fov_forward_iArr
 #define ADOLC_EXT_FCT_COMPLETE                                                 \
-  fov_forward(edfct->tapeId, n, edfct->dp_x, p, edfct->dpp_X, m, edfct->dp_y,  \
+  fov_forward(*edfct->outerTapePtr, n, edfct->dp_x, p, edfct->dpp_X, m, edfct->dp_y,  \
               edfct->dpp_Y)
 #define ADOLC_EXT_FCT_IARR_COMPLETE                                            \
-  fov_forward_iArr(edfct->tapeId, iArrLength, iArr, n, edfct->dp_x, p,         \
+  fov_forward_iArr(*edfct->outerTapePtr, iArrLength, iArr, n, edfct->dp_x, p,         \
                    edfct->dpp_X, m, edfct->dp_y, edfct->dpp_Y)
 #define ADOLC_EXT_POINTER_X edfct->dpp_X
 #define ADOLC_EXT_POINTER_Y edfct->dpp_Y
 #define ADOLC_EXT_FCT_V2_COMPLETE                                              \
-  fov_forward(edfct->tapeId, iArrLength, iArr, nin, nout, insz, edfct2->x, p,  \
+  fov_forward(*edfct->outerTapePtr, iArrLength, iArr, nin, nout, insz, edfct2->x, p,  \
               edfct2->Xp, outsz, edfct2->y, edfct2->Yp, edfct2->context)
 #define ADOLC_EXT_V2_POINTER_X edfct2->Xp
 #define ADOLC_EXT_V2_POINTER_Y edfct2->Yp
@@ -1053,7 +1052,7 @@ int hov_forward(
   /****************************************************************************/
   /*                                                           DEBUG MESSAGES */
   fprintf(DIAG_OUT, "Call of %s(..) with tag: %d, n: %d, m %d,\n",
-          GENERATED_FILENAME, tnum, indcheck, depcheck);
+          GENERATED_FILENAME, tape.tapeId(), indcheck, depcheck);
 #if defined(_KEEP_)
   fprintf(DIAG_OUT, "                    keep: %d\n", keep);
 #endif
@@ -1079,7 +1078,7 @@ int hov_forward(
     ADOLCError::fail(ADOLCError::ErrorType::REVERSE_COUNTS_MISMATCH,
                      CURRENT_LOCATION,
                      ADOLCError::FailInfo{
-                         .info1 = tnum,
+                         .info1 = tape.tapeId(),
                          .info3 = depcheck,
                          .info4 = indcheck,
                          .info5 = tape.tapestats(TapeInfos::NUM_DEPENDENTS),
@@ -1088,13 +1087,13 @@ int hov_forward(
 #if defined(_ABS_NORM_) || defined(_ABS_NORM_SIG_)
   if (!tape.tapestats(TapeInfos::NO_MIN_MAX))
     ADOLCError::fail(ADOLCError::ErrorType::NO_MINMAX, CURRENT_LOCATION,
-                     ADOLCError::FailInfo{.info1 = tnum});
+                     ADOLCError::FailInfo{.info1 = tape.tapeId()});
 
 #if defined(_ABS_NORM_SIG_) || defined(_INDOPRO_)
   if (to_size_t(swcheck) != tape.tapestats(TapeInfos::NUM_SWITCHES))
     ADOLCError::fail(
         ADOLCError::ErrorType::SWITCHES_MISMATCH, CURRENT_LOCATION,
-        ADOLCError::FailInfo{.info1 = tnum,
+        ADOLCError::FailInfo{.info1 = tape.tapeId(),
                              .info3 = swcheck,
                              .info6 = tape.tapestats(TapeInfos::NUM_SWITCHES)});
 
@@ -5507,7 +5506,7 @@ int hov_forward(
       tape.lowestXLoc_for(tape.get_locint_f());
       tape.lowestYLoc_for(tape.get_locint_f());
       tape.cp_index(tape.get_locint_f());
-      edfct = get_ext_diff_fct(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct = get_ext_diff_fct(tape, tape.ext_diff_fct_index());
 
       if (edfct->ADOLC_EXT_FCT_POINTER == nullptr)
         ADOLCError::fail(ADOLCError::ErrorType::EXT_DIFF_NULLPOINTER_DIFFFUNC,
@@ -5592,7 +5591,7 @@ int hov_forward(
       tape.lowestXLoc_for(tape.get_locint_f());
       tape.lowestYLoc_for(tape.get_locint_f());
       tape.cp_index(tape.get_locint_f());
-      edfct = get_ext_diff_fct(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct = get_ext_diff_fct(tape, tape.ext_diff_fct_index());
 
       if (edfct->ADOLC_EXT_FCT_IARR_POINTER == nullptr)
         ADOLCError::fail(ADOLCError::ErrorType::EXT_DIFF_NULLPOINTER_DIFFFUNC,
@@ -5688,7 +5687,7 @@ int hov_forward(
       }
       tape.get_locint_f(); /* nin again */
       tape.get_locint_f(); /* nout again */
-      edfct2 = get_ext_diff_fct_v2(tape.tapeId(), tape.ext_diff_fct_index());
+      edfct2 = get_ext_diff_fct_v2(tape, tape.ext_diff_fct_index());
       if (edfct2->ADOLC_EXT_FCT_POINTER == nullptr)
         ADOLCError::fail(ADOLCError::ErrorType::EXT_DIFF_NULLPOINTER_DIFFFUNC,
                          CURRENT_LOCATION);
@@ -5976,12 +5975,11 @@ int hov_forward(
 
 /****************************************************************************/
 #if defined(_ZOS_) && defined(_ABS_NORM_)
-size_t get_num_switches(short tapeId) {
-  ValueTape &tape = findTape(tapeId);
+size_t get_num_switches(ValueTape& tape) {
   tape.init_for_sweep();
   if (!tape.tapestats(TapeInfos::NO_MIN_MAX))
     ADOLCError::fail(ADOLCError::ErrorType::NO_MINMAX, CURRENT_LOCATION,
-                     ADOLCError::FailInfo{.info1 = tapeId});
+                     ADOLCError::FailInfo{.info1 = tape.tapeId()});
 
   const size_t nswitch = tape.tapestats(TapeInfos::NUM_SWITCHES);
   tape.end_sweep();

--- a/ADOL-C/src/valuetape/persistanttapeinfos.cpp
+++ b/ADOL-C/src/valuetape/persistanttapeinfos.cpp
@@ -154,13 +154,13 @@ int getThreadIndex() {
 /* Returns the char*: tapeBaseName+thread-threadNumber+tapeId+.tap+\0       */
 /* The result string must be freed be the caller!                           */
 /****************************************************************************/
-char *PersistantTapeInfos::createFileName(short tapeId, int tapeType) {
+char *PersistantTapeInfos::createFileName(int tapeType) {
   std::string fileName(tapeBaseNames_[tapeType]);
 
   int threadId = getThreadIndex();
   fileName += "thread-" + std::to_string(threadId) + "_";
 
-  fileName += "tape-" + std::to_string(tapeId) + ".tap";
+  fileName += "tape-" + std::to_string(tapeId_) + ".tap";
 
   // don't forget space for null termination
   char *ret_char = new char[fileName.size() + 1];

--- a/ADOL-C/src/valuetape/tapeinfos.cpp
+++ b/ADOL-C/src/valuetape/tapeinfos.cpp
@@ -1,9 +1,6 @@
 #include <adolc/adolcerror.h>
 #include <adolc/valuetape/tapeinfos.h>
 #include <cstring> // for memset
-#include <iostream>
-
-TapeInfos::TapeInfos(short tapeId) { tapeId_ = tapeId; }
 
 TapeInfos::~TapeInfos() {
   if (op_file) {
@@ -45,7 +42,7 @@ TapeInfos::~TapeInfos() {
 }
 
 TapeInfos::TapeInfos(TapeInfos &&other) noexcept
-    : tapeId_(other.tapeId_), numInds(other.numInds), numDeps(other.numDeps),
+    : numInds(other.numInds), numDeps(other.numDeps),
       keepTaylors(other.keepTaylors), traceFlag(other.traceFlag),
       tapingComplete(other.tapingComplete), op_file(other.op_file),
       opBuffer(other.opBuffer), currOp(other.currOp), lastOpP1(other.lastOpP1),
@@ -127,7 +124,6 @@ TapeInfos &TapeInfos::operator=(TapeInfos &&other) noexcept {
     delete[] signature;
 
     // **2. Move data members**
-    tapeId_ = other.tapeId_;
     numInds = other.numInds;
     numDeps = other.numDeps;
     keepTaylors = other.keepTaylors;

--- a/ADOL-C/src/valuetape/valuetape.cpp
+++ b/ADOL-C/src/valuetape/valuetape.cpp
@@ -24,7 +24,6 @@ void ValueTape::initTapeInfos_keep() {
   double *tayBuffer = tapeInfos_.tayBuffer;
   double *signature = tapeInfos_.signature;
   FILE *tay_file = tapeInfos_.tay_file;
-  short tapeId = tapeInfos_.tapeId_;
 
   // keep the stats to later know the number of indeps, etc...
   auto tmp_stats = tapeInfos_.stats;
@@ -46,12 +45,11 @@ void ValueTape::initTapeInfos_keep() {
   tapeInfos_.tayBuffer = tayBuffer;
   tapeInfos_.signature = signature;
   tapeInfos_.tay_file = tay_file;
-  tapeInfos_.tapeId_ = tapeId;
 }
 
 /* inits a new tape and updates the tape stack (called from start_trace)
  * - returns 0 without error
- * - returns 1 if tapeId was already/still in use */
+ * - returns 1 if tape was already/still in use */
 int ValueTape::initNewTape() {
   using ADOLCError::fail;
   using ADOLCError::FailInfo;
@@ -674,8 +672,7 @@ void ValueTape::read_params() {
 /* the taylor stack, so next reverse call will fail, if not preceded by a   */
 /* forward call after setting the parameters.                               */
 /****************************************************************************/
-void ValueTape::set_param_vec(short tag, size_t numparam,
-                              const double *paramvec) {
+void ValueTape::set_param_vec(size_t numparam, const double *paramvec) {
   using ADOLCError::fail;
   using ADOLCError::FailInfo;
   using ADOLCError::ErrorType::PARAM_COUNTS_MISMATCH;
@@ -688,7 +685,7 @@ void ValueTape::set_param_vec(short tag, size_t numparam,
   openTape();
   if (tapestats(TapeInfos::NUM_PARAM) != numparam)
     fail(PARAM_COUNTS_MISMATCH, CURRENT_LOCATION,
-         FailInfo{.info1 = tag,
+         FailInfo{.info1 = tapeId(),
                   .info5 = numparam,
                   .info6 = tapeInfos_.stats[TapeInfos::NUM_PARAM]});
 


### PR DESCRIPTION
This PR changes the methods that rely on tapeId to select a tape from a global buffer to use a reference to the tape directly. The tape_interface methods are adapted accordingly and the global tapeBuffer is removed. 

As proposed and discussed with @osander1 

- [ ] Adapt the docstrings
- [ ] Adapt latex docs

