### PR TITLE
[REF] Introduce BufferState

### DIFF
--- a/ADOL-C/boost-test/valuetape/tapeinfos.cpp
+++ b/ADOL-C/boost-test/valuetape/tapeinfos.cpp
@@ -22,43 +22,31 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   tp.keepTaylors = 1;
   tp.stats[2] = 5;
 
-  auto fileH = fopen("test_move_constr_op.txt", "w");
-  tp.op_file = fileH;
   auto opBuffer = new unsigned char[10];
-  tp.opBuffer = opBuffer;
-  tp.currOp = tp.opBuffer + 3;
-  tp.lastOpP1 = tp.opBuffer + 11;
+  tp.opBuffer_ = ADOLC::detail::OpBuffer(opBuffer, 10);
+  tp.opBuffer_.openFile("test_move_constr_op.txt", "w");
+  tp.opBuffer_.position(3);
+  tp.opBuffer_.numOnTape(10);
 
-  tp.numOps_Tape = 10;
   tp.num_eq_prod = 4;
 
-  auto fileH2 = fopen("test_move_constr_val.txt", "w");
-  tp.val_file = fileH2;
-  auto valBuffer = new double[12];
-  tp.valBuffer = valBuffer;
-  tp.currVal = tp.valBuffer + 3;
-  tp.lastValP1 = tp.valBuffer + 11;
+  auto valBuffer = new double[123];
+  tp.valBuffer_ = ADOLC::detail::ValBuffer(valBuffer, 123);
+  tp.valBuffer_.openFile("test_move_constr_val.txt", "w");
+  tp.valBuffer_.position(15);
+  tp.valBuffer_.numOnTape(123);
 
-  tp.numVals_Tape = 70;
-
-  auto fileH3 = fopen("test_move_constr_loc.txt", "w");
-  tp.loc_file = fileH3;
   auto locBuffer = new size_t[14];
+  tp.locBuffer_ = ADOLC::detail::LocBuffer(locBuffer, 14);
+  tp.locBuffer_.openFile("test_move_constr_loc.txt", "w");
+  tp.locBuffer_.position(3);
+  tp.locBuffer_.numOnTape(13);
 
-  tp.locBuffer = locBuffer;
-  tp.currLoc = tp.locBuffer + 3;
-  tp.lastLocP1 = tp.locBuffer + 13;
-
-  tp.numLocs_Tape = 13;
-
-  auto fileH4 = fopen("test_move_constr_tay.txt", "w");
-  tp.tay_file = fileH4;
   auto tayBuffer = new double[14];
-  tp.tayBuffer = tayBuffer;
-  tp.currTay = tp.tayBuffer + 4;
-  tp.lastTayP1 = tp.tayBuffer + 13;
-
-  tp.numTays_Tape = 13;
+  tp.tayBuffer_ = ADOLC::detail::TayBuffer(tayBuffer, 14);
+  tp.tayBuffer_.openFile("test_move_constr_tay.txt", "w");
+  tp.tayBuffer_.position(4);
+  tp.tayBuffer_.numOnTape(13);
 
   tp.nextBufferNumber = 4;
 
@@ -85,11 +73,12 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   BOOST_CHECK_EQUAL(tp2.numDeps, 11);
   BOOST_CHECK_EQUAL(tp2.keepTaylors, 1);
   BOOST_CHECK_EQUAL(tp2.stats[2], 5);
-  BOOST_CHECK_EQUAL(tp2.numOps_Tape, 10);
+  BOOST_CHECK_EQUAL(tp2.opBuffer_.numOnTape(), 10);
+  BOOST_CHECK_EQUAL(tp2.valBuffer_.numOnTape(), 123);
   BOOST_CHECK_EQUAL(tp2.num_eq_prod, 4);
-  BOOST_CHECK_EQUAL(tp2.numVals_Tape, 70);
-  BOOST_CHECK_EQUAL(tp2.numLocs_Tape, 13);
-  BOOST_CHECK_EQUAL(tp2.numTays_Tape, 13);
+
+  BOOST_CHECK_EQUAL(tp2.locBuffer_.numOnTape(), 13);
+  BOOST_CHECK_EQUAL(tp2.tayBuffer_.numOnTape(), 13);
   BOOST_CHECK_EQUAL(tp2.nextBufferNumber, 4);
   BOOST_CHECK_EQUAL(tp2.lastTayBlockInCore, 1);
   BOOST_CHECK_EQUAL(tp2.deg_save, 1);
@@ -101,25 +90,20 @@ BOOST_AUTO_TEST_CASE(TestMoveConstructor) {
   BOOST_CHECK_EQUAL(tp2.numSwitches, 6);
 
   // === Validate: pointers moved ===
-  BOOST_CHECK_EQUAL(tp2.op_file, fileH);
-  BOOST_CHECK_EQUAL(tp2.opBuffer, opBuffer);
-  BOOST_CHECK_EQUAL(tp2.currOp, opBuffer + 3);
-  BOOST_CHECK_EQUAL(tp2.lastOpP1, opBuffer + 11);
+  BOOST_CHECK_EQUAL(tp2.opBuffer_.file() != nullptr, true);
+  BOOST_CHECK_EQUAL(tp2.opBuffer_.begin(), opBuffer);
+  BOOST_CHECK_EQUAL(tp2.opBuffer_.position(), 3);
+  BOOST_CHECK_EQUAL(tp2.valBuffer_.file() != nullptr, true);
+  BOOST_CHECK_EQUAL(tp2.valBuffer_.begin(), valBuffer);
+  BOOST_CHECK_EQUAL(tp2.valBuffer_.position(), 15);
 
-  BOOST_CHECK_EQUAL(tp2.val_file, fileH2);
-  BOOST_CHECK_EQUAL(tp2.valBuffer, valBuffer);
-  BOOST_CHECK_EQUAL(tp2.currVal, valBuffer + 3);
-  BOOST_CHECK_EQUAL(tp2.lastValP1, valBuffer + 11);
+  BOOST_CHECK_EQUAL(tp2.locBuffer_.file() != nullptr, true);
+  BOOST_CHECK_EQUAL(tp2.locBuffer_.begin(), locBuffer);
+  BOOST_CHECK_EQUAL(tp2.locBuffer_.position(), 3);
 
-  BOOST_CHECK_EQUAL(tp2.loc_file, fileH3);
-  BOOST_CHECK_EQUAL(tp2.locBuffer, locBuffer);
-  BOOST_CHECK_EQUAL(tp2.currLoc, locBuffer + 3);
-  BOOST_CHECK_EQUAL(tp2.lastLocP1, locBuffer + 13);
-
-  BOOST_CHECK_EQUAL(tp2.tay_file, fileH4);
-  BOOST_CHECK_EQUAL(tp2.tayBuffer, tayBuffer);
-  BOOST_CHECK_EQUAL(tp2.currTay, tayBuffer + 4);
-  BOOST_CHECK_EQUAL(tp2.lastTayP1, tayBuffer + 13);
+  BOOST_CHECK_EQUAL(tp2.tayBuffer_.file() != nullptr, true);
+  BOOST_CHECK_EQUAL(tp2.tayBuffer_.begin(), tayBuffer);
+  BOOST_CHECK_EQUAL(tp2.tayBuffer_.position(), 4);
   BOOST_CHECK_EQUAL(tp2.signature, l);
 }
 

--- a/ADOL-C/include/adolc/valuetape/CMakeLists.txt
+++ b/ADOL-C/include/adolc/valuetape/CMakeLists.txt
@@ -1,4 +1,5 @@
 install(FILES
+        bufferstate.h
         globaltapevarscl.h
         infotype.h
         tapeinfos.h

--- a/ADOL-C/include/adolc/valuetape/bufferstate.h
+++ b/ADOL-C/include/adolc/valuetape/bufferstate.h
@@ -1,0 +1,220 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <memory>
+
+#ifndef ADOLC_BUFFER_STATE
+#define ADOLC_BUFFER_STATE
+
+namespace ADOLC::detail {
+
+struct FileDeleter {
+  int operator()(FILE *file) { return fclose(file); }
+};
+/**
+ * @brief Owning buffer wrapper used by the ADOL-C tape implementation.
+ *
+ * BufferState groups the state that is common to the operation, value,
+ * location, and Taylor tapes:
+ *   - a FILE handle for disk-backed tape blocks,
+ *   - an owned heap buffer,
+ *   - the current position inside that buffer,
+ *   - the buffer capacity,
+ *   - the number of elements currently recorded on the complete tape.
+ *
+ * The buffer behaves like a small pointer abstraction. position() is the
+ * index of the current element. Writing usually stores into current() and then
+ * advances the buffer; reading in reverse usually retreats first and then
+ * consumes the returned element.
+ *
+ * Ownership:
+ *   - allocated buffers are deleted by the destructor,
+ *   - FILE handles are closed by the unique_ptr deleter,
+ *   - releaseBuffer() and releaseFile() transfer ownership back to the caller.
+ *
+ * @tparam T Element type stored by this tape buffer.
+ */
+template <typename T> class BufferState {
+  using FilePtr = std::unique_ptr<FILE, FileDeleter>;
+  FilePtr file_{nullptr, FileDeleter{}};
+  T *buffer_{nullptr};
+  size_t currentPos_{0};
+  size_t capacity_{0};
+  size_t numOnTape_{0};
+
+public:
+  /// Deletes the owned buffer and closes the owned file handle, if present.
+  ~BufferState() { delete[] buffer_; }
+
+  BufferState() = default;
+
+  /// Takes ownership of an existing heap buffer with the given capacity.
+  BufferState(T *buffer, size_t capacity)
+      : buffer_(buffer), capacity_(capacity) {};
+
+  /// BufferState owns resources and is therefore move-only.
+  BufferState(const BufferState &other) = delete;
+  BufferState &operator=(const BufferState &other) = delete;
+
+  /// Moves the file handle, buffer, position, capacity, and tape counter.
+  BufferState(BufferState &&other) noexcept {
+    file_ = std::move(other.file_);
+    buffer_ = other.buffer_;
+    other.buffer_ = nullptr;
+    capacity_ = other.capacity_;
+    currentPos_ = other.currentPos_;
+    numOnTape_ = other.numOnTape_;
+    other.currentPos_ = 0;
+    other.capacity_ = 0;
+    other.numOnTape_ = 0;
+  }
+
+  /// Releases current resources, then moves all resources from other.
+  BufferState &operator=(BufferState &&other) noexcept {
+    if (this != &other) {
+      file_ = std::move(other.file_);
+      other.file_ = nullptr;
+      delete[] buffer_;
+      buffer_ = other.buffer_;
+      other.buffer_ = nullptr;
+      capacity_ = other.capacity_;
+      currentPos_ = other.currentPos_;
+      numOnTape_ = other.numOnTape_;
+      other.currentPos_ = 0;
+      other.capacity_ = 0;
+      other.numOnTape_ = 0;
+    }
+    return *this;
+  }
+
+  /// Takes ownership of file, closing any previously owned file handle.
+  void resetFile(FILE *file) { file_.reset(file); }
+
+  /// Returns the owned FILE handle without transferring ownership.
+  FILE *file() { return file_.get(); }
+  FILE *file() const { return file_.get(); }
+
+  /// Closes the owned FILE handle, if present.
+  void closeFile() { file_.reset(); }
+
+  /// Releases the FILE handle without closing it.
+  FILE *releaseFile() { return file_.release(); }
+
+  /// Opens fileName with mode and owns the resulting FILE handle.
+  void openFile(const char *fileName, const char *mode) {
+    file_.reset(fopen(fileName, mode));
+  }
+
+  /**
+   * @brief Replaces the buffer pointer.
+   *
+   * The new pointer is treated as owned by BufferState.
+   */
+  void resetBuffer(T *buffer, size_t capacity) {
+    delete[] buffer_;
+    buffer_ = buffer;
+    capacity_ = capacity;
+    currentPos_ = 0;
+  }
+
+  /// Returns the beginning of the owned buffer.
+  T *begin() { return buffer_; }
+  const T *begin() const { return buffer_; }
+
+  /**
+   * @brief Releases the owned buffer without deleting it.
+   *
+   * The capacity and current position are reset because the wrapper no longer
+   * has a valid in-memory buffer. numOnTape() is left unchanged.
+   */
+  T *releaseBuffer() {
+    T *buffer = buffer_;
+    buffer_ = nullptr;
+    capacity_ = 0;
+    currentPos_ = 0;
+    return buffer;
+  }
+
+  /// Allocates a new owned buffer if no buffer is currently present.
+  void allocIfNull(size_t capacity) {
+    if (buffer_ == nullptr) {
+      buffer_ = new T[capacity];
+      capacity_ = capacity;
+    }
+  }
+
+  /// Returns the current buffer index.
+  size_t position() const { return currentPos_; }
+
+  /// Sets the current buffer index.
+  void position(size_t pos) {
+    assert(pos <= capacity_);
+    currentPos_ = pos;
+  }
+
+  /// Returns how many elements fit between position() and capacity().
+  size_t remainingCapacity() const { return capacity_ - currentPos_; }
+
+  /// Returns the capacity of the owned buffer.
+  size_t capacity() const { return capacity_; }
+
+  /// Returns the number of elements recorded on the tape.
+  size_t numOnTape() const { return numOnTape_; }
+
+  /// Sets the number of elements recorded on the tape.
+  void numOnTape(size_t num) { numOnTape_ = num; }
+
+  /// Returns a copy of the element at idx.
+  const T &operator[](size_t idx) const {
+    assert(idx < capacity_);
+    return buffer_[idx];
+  }
+
+  /// Returns a mutable reference to the element at idx.
+  T &operator[](size_t idx) {
+    assert(idx < capacity_);
+    return buffer_[idx];
+  }
+
+  /// Stores val at position().
+  void writeCurrent(T val) {
+    assert(currentPos_ < capacity_);
+    buffer_[currentPos_] = val;
+  }
+
+  /// Stores val at position(), then advances to the next element.
+  void writeAndAdvance(T val) {
+    writeCurrent(val);
+    advance();
+  }
+
+  /// Returns a pointer to the element at position().
+  T *current() { return buffer_ + currentPos_; }
+  const T *current() const { return buffer_ + currentPos_; }
+
+  /// Advances the current position by one element.
+  void advance() {
+    assert(currentPos_ < capacity_);
+    ++currentPos_;
+  }
+
+  /// Moves the current position back by one element.
+  void retreat() {
+    assert(currentPos_ > 0);
+    --currentPos_;
+  }
+
+  /// Returns the current element, then advances position().
+  T readAndAdvance() { return (*this)[currentPos_++]; }
+
+  /// Moves to the previous element, then returns it.
+  T retreatAndRead() { return (*this)[--currentPos_]; }
+};
+
+/// Operation tape buffer.
+using OpBuffer = BufferState<unsigned char>;
+using ValBuffer = BufferState<double>;
+using LocBuffer = BufferState<size_t>;
+using TayBuffer = BufferState<double>;
+}; // namespace ADOLC::detail
+#endif // ADOLC_BUFFER_STATE

--- a/ADOL-C/include/adolc/valuetape/infotype.h
+++ b/ADOL-C/include/adolc/valuetape/infotype.h
@@ -5,7 +5,6 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdio>
-#include <string_view>
 
 /*
   This header defines a small “policy” interface used by ADOL-C tape I/O code.
@@ -54,35 +53,34 @@ namespace ADOLC::detail {
  *     (constexpr) and the exact reference category is not important.
  */
 template <class T, class TInfos, class ErrorType>
-concept InfoTypeBase =
-    requires(TInfos &tapeInfos, std::string_view fileName, std::string_view) {
-      // element type stored in the tape buffer
-      typename T::value_type;
+concept InfoTypeBase = requires(TInfos &tapeInfos, const char *fileName) {
+  // element type stored in the tape buffer
+  typename T::value_type;
 
-      // “statistic entry” identifiers used by ADOL-C bookkeeping
-      { T::num } -> std::same_as<const typename TInfos::StatEntries &>;
-      { T::bufferSize } -> std::same_as<const typename TInfos::StatEntries &>;
+  // “statistic entry” identifiers used by ADOL-C bookkeeping
+  { T::num } -> std::same_as<const typename TInfos::StatEntries &>;
+  { T::bufferSize } -> std::same_as<const typename TInfos::StatEntries &>;
 
-      // error code associated with this tape type (must be usable as ErrorType)
-      { T::error } -> std::convertible_to<ErrorType>;
+  // error code associated with this tape type (must be usable as ErrorType)
+  { T::error } -> std::convertible_to<ErrorType>;
 
-      // number of elements read/written per I/O chunk (must be usable as
-      // size_t)
-      { T::chunkSize } -> std::convertible_to<size_t>;
+  // number of elements read/written per I/O chunk (must be usable as
+  // size_t)
+  { T::chunkSize } -> std::convertible_to<size_t>;
 
-      // pointer to the begin of the tape buffer
-      { T::bufferBegin(tapeInfos) } -> std::same_as<typename T::value_type *>;
+  // pointer to the begin of the tape buffer
+  { T::bufferBegin(tapeInfos) } -> std::same_as<typename T::value_type *>;
 
-      // map generic “current pointer” and “count” operations to TInfos fields
-      T::setCurr(tapeInfos, (typename T::value_type *)nullptr);
-      T::setNum(tapeInfos, size_t{});
-      { T::getNum(tapeInfos) };
+  // map generic “current pointer” and “count” operations to TInfos fields
+  T::setCurr(tapeInfos, size_t{});
+  T::setNum(tapeInfos, size_t{});
+  { T::getNum(tapeInfos) };
 
-      // file handle access and file lifecycle operations
-      T::file(tapeInfos);
-      T::openFile(tapeInfos, fileName);
-      { T::removeFile(fileName) } -> std::same_as<int>;
-    };
+  // file handle access and file lifecycle operations
+  T::file(tapeInfos);
+  T::openFile(tapeInfos, fileName);
+  { T::removeFile(fileName) } -> std::same_as<int>;
+};
 
 template <class T, class TInfos>
 concept HasFileAccessEntry = requires {
@@ -124,10 +122,7 @@ static size_t write(TInfos &tapeInfos, size_t chunk, size_t size) {
  * @brief Adapter for the operations tape (op tape). Fulfills InfoType.
  *
  * Maps generic operations to:
- *   - tapeInfos.numOps_Tape
- *   - tapeInfos.currOp
- *   - tapeInfos.opBuffer
- *   - tapeInfos.op_file
+ *   - tapeInfos.opBuffer_
  *
  * The StatEntries constants (num/fileAccess/bufferSize) are used for ADOL-C
  * statistics/counters.
@@ -144,34 +139,33 @@ template <class TInfos, class EType> struct OpInfo {
 
   static constexpr size_t chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(value_type);
 
-  static void setNum(TInfos &tapeInfos, size_t n) { tapeInfos.numOps_Tape = n; }
-  static size_t getNum(TInfos &tapeInfos) { return tapeInfos.numOps_Tape; }
-  static void setCurr(TInfos &tapeInfos, value_type *p) {
-    tapeInfos.currOp = p;
+  static void setNum(TInfos &tapeInfos, size_t n) {
+    tapeInfos.opBuffer_.numOnTape(n);
+  }
+  static size_t getNum(TInfos &tapeInfos) {
+    return tapeInfos.opBuffer_.numOnTape();
+  }
+  static void setCurr(TInfos &tapeInfos, size_t loc) {
+    tapeInfos.opBuffer_.position(loc);
   }
 
   static value_type *bufferBegin(TInfos &tapeInfos) {
-    return tapeInfos.opBuffer;
+    return tapeInfos.opBuffer_.begin();
   }
 
-  static FILE *file(TInfos &tapeInfos) { return tapeInfos.op_file; }
-  static void openFile(TInfos &tapeInfos, std::string_view fileName,
-                       std::string_view mode = "rb") {
-    tapeInfos.op_file = fopen(fileName.data(), mode.data());
+  static FILE *file(TInfos &tapeInfos) { return tapeInfos.opBuffer_.file(); }
+  static void openFile(TInfos &tapeInfos, const char *fileName,
+                       const char *mode = "rb") {
+    tapeInfos.opBuffer_.openFile(fileName, mode);
   }
-  static int removeFile(std::string_view fileName) {
-    return remove(fileName.data());
-  }
+  static int removeFile(const char *fileName) { return remove(fileName); }
 };
 
 /**
  * @brief Adapter for the locations tape (loc tape). Fulfills InfoType.
  *
  * Maps generic operations to:
- *   - tapeInfos.numLocs_Tape
- *   - tapeInfos.currLoc
- *   - tapeInfos.locBuffer
- *   - tapeInfos.loc_file
+ *   - tapeInfos.locBuffer_
  */
 template <class TInfos, class EType> struct LocInfo {
   using value_type = size_t;
@@ -186,35 +180,32 @@ template <class TInfos, class EType> struct LocInfo {
   static constexpr size_t chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(value_type);
 
   static void setNum(TInfos &tapeInfos, size_t n) {
-    tapeInfos.numLocs_Tape = n;
+    tapeInfos.locBuffer_.numOnTape(n);
   }
-  static size_t getNum(TInfos &tapeInfos) { return tapeInfos.numLocs_Tape; }
-  static void setCurr(TInfos &tapeInfos, value_type *p) {
-    tapeInfos.currLoc = p;
+  static size_t getNum(TInfos &tapeInfos) {
+    return tapeInfos.locBuffer_.numOnTape();
+  }
+  static void setCurr(TInfos &tapeInfos, size_t loc) {
+    tapeInfos.locBuffer_.position(loc);
   }
 
   static value_type *bufferBegin(TInfos &tapeInfos) {
-    return tapeInfos.locBuffer;
+    return tapeInfos.locBuffer_.begin();
   }
 
-  static FILE *file(TInfos &tapeInfos) { return tapeInfos.loc_file; }
-  static void openFile(TInfos &tapeInfos, std::string_view fileName,
-                       std::string_view mode = "rb") {
-    tapeInfos.loc_file = fopen(fileName.data(), mode.data());
+  static FILE *file(TInfos &tapeInfos) { return tapeInfos.locBuffer_.file(); }
+  static void openFile(TInfos &tapeInfos, const char *fileName,
+                       const char *mode = "rb") {
+    tapeInfos.locBuffer_.openFile(fileName, mode);
   }
-  static int removeFile(std::string_view fileName) {
-    return remove(fileName.data());
-  }
+  static int removeFile(const char *fileName) { return remove(fileName); }
 };
 
 /**
  * @brief Adapter for the values tape (val tape). Fulfills InfoType.
  *
  * Maps generic operations to:
- *   - tapeInfos.numVals_Tape
- *   - tapeInfos.currVal
- *   - tapeInfos.valBuffer
- *   - tapeInfos.val_file
+ *   - tapeInfos.valBuffer_
  */
 template <class TInfos, class EType> struct ValInfo {
   using value_type = double;
@@ -230,35 +221,32 @@ template <class TInfos, class EType> struct ValInfo {
   static constexpr size_t chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(value_type);
 
   static void setNum(TInfos &tapeInfos, size_t n) {
-    tapeInfos.numVals_Tape = n;
+    tapeInfos.valBuffer_.numOnTape(n);
   }
-  static size_t getNum(TInfos &tapeInfos) { return tapeInfos.numVals_Tape; }
-  static void setCurr(TInfos &tapeInfos, value_type *p) {
-    tapeInfos.currVal = p;
+  static size_t getNum(TInfos &tapeInfos) {
+    return tapeInfos.valBuffer_.numOnTape();
+  }
+  static void setCurr(TInfos &tapeInfos, size_t loc) {
+    tapeInfos.valBuffer_.position(loc);
   }
 
   static value_type *bufferBegin(TInfos &tapeInfos) {
-    return tapeInfos.valBuffer;
+    return tapeInfos.valBuffer_.begin();
   }
 
-  static FILE *file(TInfos &tapeInfos) { return tapeInfos.val_file; }
-  static void openFile(TInfos &tapeInfos, std::string_view fileName,
-                       std::string_view mode = "rb") {
-    tapeInfos.val_file = fopen(fileName.data(), mode.data());
+  static FILE *file(TInfos &tapeInfos) { return tapeInfos.valBuffer_.file(); }
+  static void openFile(TInfos &tapeInfos, const char *fileName,
+                       const char *mode = "rb") {
+    tapeInfos.valBuffer_.openFile(fileName, mode);
   }
-  static int removeFile(std::string_view fileName) {
-    return remove(fileName.data());
-  }
+  static int removeFile(const char *fileName) { return remove(fileName); }
 };
 
 /**
  * @brief Adapter for the Taylor tape (tay tape). Fulfills InfoTypeBase.
  *
  * Maps generic operations to:
- *   - tapeInfos.numTays_Tape
- *   - tapeInfos.currTay
- *   - tapeInfos.tayBuffer
- *   - tapeInfos.tay_file
+ *   - tapeInfos.tayBuffer_
  */
 template <class TInfos, class EType> struct TayInfo {
   using value_type = double;
@@ -272,25 +260,25 @@ template <class TInfos, class EType> struct TayInfo {
   static constexpr size_t chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(value_type);
 
   static void setNum(TInfos &tapeInfos, size_t n) {
-    tapeInfos.numTays_Tape = n;
+    tapeInfos.tayBuffer_.numOnTape(n);
   }
-  static size_t getNum(TInfos &tapeInfos) { return tapeInfos.numTays_Tape; }
-  static void setCurr(TInfos &tapeInfos, value_type *p) {
-    tapeInfos.currTay = p;
+  static size_t getNum(TInfos &tapeInfos) {
+    return tapeInfos.tayBuffer_.numOnTape();
+  }
+  static void setCurr(TInfos &tapeInfos, size_t loc) {
+    tapeInfos.tayBuffer_.position(loc);
   }
 
   static value_type *bufferBegin(TInfos &tapeInfos) {
-    return tapeInfos.tayBuffer;
+    return tapeInfos.tayBuffer_.begin();
   }
 
-  static FILE *file(TInfos &tapeInfos) { return tapeInfos.tay_file; }
-  static void openFile(TInfos &tapeInfos, std::string_view fileName,
-                       std::string_view mode = "rb") {
-    tapeInfos.tay_file = fopen(fileName.data(), mode.data());
+  static FILE *file(TInfos &tapeInfos) { return tapeInfos.tayBuffer_.file(); }
+  static void openFile(TInfos &tapeInfos, const char *fileName,
+                       const char *mode = "rb") {
+    tapeInfos.tayBuffer_.openFile(fileName, mode);
   }
-  static int removeFile(std::string_view fileName) {
-    return remove(fileName.data());
-  }
+  static int removeFile(const char *fileName) { return remove(fileName); }
 };
 }; // namespace ADOLC::detail
 

--- a/ADOL-C/include/adolc/valuetape/tapeinfos.h
+++ b/ADOL-C/include/adolc/valuetape/tapeinfos.h
@@ -4,6 +4,7 @@
 #include <adolc/adalloc.h>
 #include <adolc/adolcerror.h>
 #include <adolc/oplate.h>
+#include <adolc/valuetape/bufferstate.h>
 #include <adolc/valuetape/infotype.h>
 #include <array>
 #include <memory>
@@ -46,47 +47,20 @@ struct TapeInfos {
   TapeInfos(TapeInfos &&other) noexcept;
   TapeInfos &operator=(TapeInfos &&other) noexcept;
 
+  ADOLC::detail::OpBuffer opBuffer_{};
+  ADOLC::detail::ValBuffer valBuffer_{};
+  ADOLC::detail::LocBuffer locBuffer_{};
+  ADOLC::detail::TayBuffer tayBuffer_{};
+  std::array<size_t, STAT_SIZE> stats{};
+
   short tapeId_{-1};
   size_t numInds{0};
   size_t numDeps{0};
   // 1 - write taylor stack in taping mode
   int keepTaylors{0};
-  std::array<size_t, STAT_SIZE> stats{};
 
-  /* ------ operations tape ------- */
-  // file descriptor
-  FILE *op_file{nullptr};
-  // pointer to the current tape buffer
-  unsigned char *opBuffer{nullptr};
-  // pointer to the current opcode
-  unsigned char *currOp{nullptr};
-  // pointer to element following the buffer
-  unsigned char *lastOpP1{nullptr};
-  // overall number of opcodes
-  size_t numOps_Tape{0};
-  // overall number of eq_*_prod for nlf
   size_t num_eq_prod{0};
 
-  /* --------- values (real) tape ------- */
-  FILE *val_file{nullptr};
-  double *valBuffer{nullptr};
-  double *currVal{nullptr};
-  double *lastValP1{nullptr};
-  size_t numVals_Tape{0};
-
-  /* ---------- locations tape --------- */
-  FILE *loc_file{nullptr};
-  size_t *locBuffer{nullptr};
-  size_t *currLoc{nullptr};
-  size_t *lastLocP1{nullptr};
-  size_t numLocs_Tape{0};
-
-  /* taylor stack tape */
-  FILE *tay_file{nullptr};
-  double *tayBuffer{nullptr};
-  double *currTay{nullptr};
-  double *lastTayP1{nullptr};
-  size_t numTays_Tape{0};
   // the next Buffer to read back
   size_t nextBufferNumber{0};
   // == 1 if last taylor buffer is still in
@@ -128,17 +102,17 @@ struct TapeInfos {
 
   ///@brief returns current taylor coefficient and advances the stack pointer
   double get_taylor() {
-    if (currTay == tayBuffer)
+    if (tayBuffer_.position() == 0)
       get_tay_block_r();
-    return *(--currTay);
+    return tayBuffer_.retreatAndRead();
   }
   // writes a single element (x) to the taylor buffer and writes the buffer
   // to disk if necessary
   void write_scaylor(double val, const char *tay_fileName) {
-    if (currTay == lastTayP1)
-      put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName, lastTayP1);
-    *currTay = val;
-    ++currTay;
+    if (tayBuffer_.position() == tayBuffer_.capacity())
+      put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName,
+                                               tayBuffer_.capacity());
+    tayBuffer_.writeAndAdvance(val);
   }
 
   /****************************************************************************/
@@ -171,10 +145,7 @@ struct TapeInfos {
   void get_tay_block_r();
 
   // functions for handling loc tape
-  void put_loc(size_t loc) {
-    *currLoc = loc;
-    ++currLoc;
-  }
+  void put_loc(size_t loc) { locBuffer_.writeAndAdvance(loc); }
 
   void get_loc_block_f();
   void get_loc_block_r();
@@ -219,7 +190,7 @@ struct TapeInfos {
    * maps the generic operations to the appropriate TInfos fields.
    */
   template <InfoTypeBase<TapeInfos, ErrorType> Info>
-  void openFile(std::string_view fileName) {
+  void openFile(const char *fileName) {
     using ADOLCError::ErrorType::CANNOT_REMOVE_FILE;
     if (Info::file(*this) == nullptr) {
       if constexpr (!std::is_same_v<Info, TayInfo<TapeInfos, ErrorType>>) {
@@ -263,16 +234,13 @@ struct TapeInfos {
    *    periodically flushed to disk to avoid excessive I/O calls.
    */
   template <InfoTypeBase<TapeInfos, ErrorType> Info>
-  void put_block(std::string_view fileName,
-                 const typename Info::value_type *bufferPos) {
+  void put_block(const char *fileName, size_t lengthBlock) {
     using ADOLC::detail::write;
     using ADOLCError::fail;
     using ADOLCError::ErrorType::CANNOT_REMOVE_FILE;
     using ADOLCError::ErrorType::TAPING_FATAL_IO_ERROR;
 
     openFile<Info>(fileName);
-
-    const std::size_t lengthBlock = bufferPos - Info::bufferBegin(*this);
     const size_t numChunks = lengthBlock / Info::chunkSize;
 
     // write full chunks
@@ -293,7 +261,7 @@ struct TapeInfos {
     }
 
     Info::setNum(*this, Info::getNum(*this) + lengthBlock);
-    Info::setCurr(*this, Info::bufferBegin(*this));
+    Info::setCurr(*this, 0);
   }
   // functions for handling val tape
 
@@ -302,8 +270,7 @@ struct TapeInfos {
   /****************************************************************************/
   void put_vals_notWriteBlock(double *vals, size_t numVals) {
     for (size_t i = 0; i < numVals; ++i) {
-      *currVal = vals[i];
-      ++currVal;
+      valBuffer_.writeAndAdvance(vals[i]);
     }
   }
   void put_vals_writeBlock(double *vals, size_t numVals,
@@ -315,21 +282,24 @@ struct TapeInfos {
   /* vector. -- Forward Mode --                                               */
   /****************************************************************************/
   double *get_val_v_f(size_t size) {
-    double *temp = currVal;
-    currVal += size;
+    double *temp = valBuffer_.current();
+    valBuffer_.position(valBuffer_.position() + size);
     return temp;
   }
   /****************************************************************************/
   /* Returns a pointer to the first element of a values vector and skips the  */
   /* vector. -- Reverse Mode --                                               */
   /****************************************************************************/
-  double *get_val_v_r(size_t size) { return currVal -= size; }
+  double *get_val_v_r(size_t size) {
+    valBuffer_.position(valBuffer_.position() - size);
+    return valBuffer_.current();
+  }
 
   /****************************************************************************/
   /* Not sure what's going on here! -> vector class ?  --- kowarz             */
   /****************************************************************************/
   void reset_val_r(void) {
-    if (currVal == valBuffer)
+    if (valBuffer_.position() == 0)
       get_val_block_r();
   }
 
@@ -341,10 +311,10 @@ struct TapeInfos {
     // LocBuffer points to the first entry of the Locations and CurrLoc-1 to the
     // last placed location in the buffer. Thus, the check ask if there is no
     // element on the tape.
-    if (currLoc - locBuffer < 1)
+    if (locBuffer_.position() < 1)
       return 0;
-    if (temp == *(currLoc - 1)) {
-      *(currLoc - 1) = lhs;
+    if (temp == locBuffer_[locBuffer_.position() - 1]) {
+      locBuffer_[locBuffer_.position() - 1] = lhs;
       return 1;
     }
     return 0;
@@ -354,10 +324,10 @@ struct TapeInfos {
     // LocBuffer points to the first entry of the Locations and CurrLoc-1 to the
     // last placed location in the buffer. Thus, the check ask if there is no
     // element on the tape.
-    if (currLoc - locBuffer < 1)
+    if (locBuffer_.position() < 1)
       return 0;
     // checks if tape-element represented by "tmp" is the last created.
-    if (temp == *(currLoc - 1)) {
+    if (temp == locBuffer_[locBuffer_.position() - 1]) {
       return 1;
     }
     return 0;
@@ -368,15 +338,17 @@ struct TapeInfos {
   /* temporary variables. e.g.  t = a * b ; y += t  =>  y += a * b            */
   /****************************************************************************/
   int upd_resloc_inc_prod(size_t temp, size_t newlhs, unsigned char newop) {
-    if (currLoc - locBuffer < 3)
+    if (locBuffer_.position() < 3)
       return 0;
-    if (currOp - opBuffer < 1)
+    if (opBuffer_.position() < 1)
       return 0;
-    if (temp == *(currLoc - 1) && mult_a_a == *(currOp - 1) &&
+    if (temp == locBuffer_[locBuffer_.position() - 1] &&
+        mult_a_a == opBuffer_[opBuffer_.position() - 1] &&
         /* skipping recursive case */
-        newlhs != *(currLoc - 2) && newlhs != *(currLoc - 3)) {
-      *(currLoc - 1) = newlhs;
-      *(currOp - 1) = newop;
+        newlhs != locBuffer_[locBuffer_.position() - 2] &&
+        newlhs != locBuffer_[locBuffer_.position() - 3]) {
+      locBuffer_[locBuffer_.position() - 1] = newlhs;
+      opBuffer_[opBuffer_.position() - 1] = newop;
       return 1;
     }
     return 0;
@@ -386,38 +358,32 @@ struct TapeInfos {
 /*                                                          DEBUG FUNCTIONS */
 #ifdef ADOLC_HARDDEBUG
   unsigned char get_op_f() {
-    unsigned char temp = *currOp;
-    ++currOp;
+    unsigned char temp = opBuffer_.readAndAdvance();
     fprintf(DIAG_OUT, "f_op: %i\n", temp - '\0'); /* why -'\0' ??? kowarz */
     return temp;
   }
   unsigned char get_op_r() {
-    --currOp;
-    unsigned char temp = *currOp;
+    unsigned char temp = opBuffer_.retreatAndRead();
     fprintf(DIAG_OUT, "r_op: %i\n", temp - '\0');
     return temp;
   }
   size_t get_size_t_f() {
-    size_t temp = *currLoc;
-    ++currLoc;
+    size_t temp = locBuffer_.readAndAdvance();
     fprintf(DIAG_OUT, "f_loc: %i\n", temp);
     return temp;
   }
   size_t get_size_t_r() {
-    --currLoc;
-    unsigned char temp = *currLoc;
+    size_t temp = locBuffer_.retreatAndRead();
     fprintf(DIAG_OUT, "r_loc: %i\n", temp);
     return temp;
   }
   double get_val_f() {
-    double temp = *currVal;
-    ++currVal;
+    double temp = valBuffer_.readAndAdvance();
     fprintf(DIAG_OUT, "f_val: %e\n", temp);
     return temp;
   }
   double get_val_r() {
-    --currVal;
-    double temp = *currVal;
+    double temp = valBuffer_.retreatAndRead();
     fprintf(DIAG_OUT, "r_val: %e\n", temp);
     return temp;
   }

--- a/ADOL-C/include/adolc/valuetape/valuetape.h
+++ b/ADOL-C/include/adolc/valuetape/valuetape.h
@@ -229,24 +229,19 @@ public:
   void workMode(TapeInfos::WORKMODES mode) { tapeInfos_.workMode = mode; }
   TapeInfos::WORKMODES workMode() const { return tapeInfos_.workMode; }
 
-  void increment_numTays_Tape() { ++(tapeInfos_.numTays_Tape); }
-  void add_numTays_Tape(size_t val) { tapeInfos_.numTays_Tape += val; }
-  size_t numTays_Tape() const { return tapeInfos_.numTays_Tape; }
-  void numTays_Tape(size_t val) { tapeInfos_.numTays_Tape = val; }
-
-  size_t numLocs_Tape() const { return tapeInfos_.numLocs_Tape; }
-  void numLocs_Tape(size_t num) { tapeInfos_.numLocs_Tape = num; }
-
-  size_t numOps_Tape() const { return tapeInfos_.numOps_Tape; }
-  void numOps_Tape(size_t num) { tapeInfos_.numOps_Tape = num; }
-
-  size_t numVals_Tape() const { return tapeInfos_.numVals_Tape; }
-  void numVals_Tape(size_t num) { tapeInfos_.numVals_Tape = num; }
+  void increment_numTays_Tape() {
+    tapeInfos_.tayBuffer_.numOnTape(tapeInfos_.tayBuffer_.numOnTape() + 1);
+  }
+  void add_numTays_Tape(size_t val) {
+    tapeInfos_.tayBuffer_.numOnTape(tapeInfos_.tayBuffer_.numOnTape() + val);
+  }
 
   void lastTayBlockInCore(char val) { tapeInfos_.lastTayBlockInCore = val; }
   char lastTayBlockInCore() const { return tapeInfos_.lastTayBlockInCore; }
 
-  void decrement_numTays_Tape() { --(tapeInfos_.numTays_Tape); }
+  void decrement_numTays_Tape() {
+    tapeInfos_.tayBuffer_.numOnTape(tapeInfos_.tayBuffer_.numOnTape() - 1);
+  }
 
   size_t num_eq_prod() const { return tapeInfos_.num_eq_prod; }
   void num_eq_prod(size_t num) { tapeInfos_.num_eq_prod = num; }
@@ -276,29 +271,6 @@ public:
     tapeInfos_.ext_diff_fct_index = index;
   }
 
-  unsigned char *currOp() const { return tapeInfos_.currOp; }
-  void currOp(unsigned char *op) { tapeInfos_.currOp = op; }
-
-  size_t *currLoc() const { return tapeInfos_.currLoc; }
-  void currLoc(size_t *loc) { tapeInfos_.currLoc = loc; }
-
-  double *currVal() const { return tapeInfos_.currVal; }
-  void currVal(double *val) { tapeInfos_.currVal = val; }
-
-  double *currTay() const { return tapeInfos_.currTay; }
-  void currTay(double *pos) { tapeInfos_.currTay = pos; }
-  void currTay(double val) { *tapeInfos_.currTay = val; }
-  void decrement_currTay() { --tapeInfos_.currTay; }
-
-  void lastTayP1(double *pos) { tapeInfos_.lastTayP1 = pos; }
-  double *lastTayP1() const { return tapeInfos_.lastTayP1; }
-
-  void lastOpP1(unsigned char *lastOp) { tapeInfos_.lastOpP1 = lastOp; }
-  void lastLocP1(size_t *lastLoc) { tapeInfos_.lastLocP1 = lastLoc; }
-
-  void lastValP1(double *lastVal) { tapeInfos_.lastValP1 = lastVal; }
-  double *lastValP1() const { return tapeInfos_.lastValP1; }
-
   void nextBufferNumber(size_t num) { tapeInfos_.nextBufferNumber = num; }
   size_t nextBufferNumber() const { return tapeInfos_.nextBufferNumber; }
   void decrement_nextBufferNumber() { --tapeInfos_.nextBufferNumber; }
@@ -324,12 +296,12 @@ public:
   void get_loc_block_r() { return tapeInfos_.get_loc_block_r(); };
   void put_loc(size_t loc) { return tapeInfos_.put_loc(loc); };
 #ifndef ADOLC_HARDDEBUG
-  char get_op_f() { return *(tapeInfos_.currOp)++; }
-  char get_op_r() { return *--(tapeInfos_.currOp); }
-  size_t get_locint_f() { return *(tapeInfos_.currLoc)++; }
-  size_t get_locint_r() { return *--(tapeInfos_.currLoc); }
-  double get_val_f() { return *(tapeInfos_.currVal)++; }
-  double get_val_r() { return *--(tapeInfos_.currVal); }
+  char get_op_f() { return tapeInfos_.opBuffer_.readAndAdvance(); }
+  char get_op_r() { return tapeInfos_.opBuffer_.retreatAndRead(); }
+  size_t get_locint_f() { return tapeInfos_.locBuffer_.readAndAdvance(); }
+  size_t get_locint_r() { return tapeInfos_.locBuffer_.retreatAndRead(); }
+  double get_val_f() { return tapeInfos_.valBuffer_.readAndAdvance(); }
+  double get_val_r() { return tapeInfos_.valBuffer_.retreatAndRead(); }
 #else
   unsigned char ValueTape::get_op_f() { return tapeInfos_.get_op_f(); }
   unsigned char ValueTape::get_op_r() { return tapeInfos_.get_op_r(); }
@@ -338,10 +310,7 @@ public:
   double ValueTape::get_val_f() { return tapeInfos_.get_val_f(); }
   double ValueTape::get_val_r() { return tapeInfos_.get_val_r(); }
 #endif // ADOLC_HARDDEBUG
-  void put_val(const double val) {
-    *tapeInfos_.currVal = val;
-    ++tapeInfos_.currVal;
-  }
+  void put_val(const double val) { tapeInfos_.valBuffer_.writeAndAdvance(val); }
   /* puts a single constant into the location buffer, no disk access */
   void put_vals_writeBlock(double *reals, size_t numReals) {
     return tapeInfos_.put_vals_writeBlock(reals, numReals, op_fileName(),
@@ -387,25 +356,8 @@ public:
   void nestedReverseEval(bool flag) { tapeInfos_.nestedReverseEval = flag; }
   // Returns whether reverse evaluation should accumulate into an outer tape.
   bool nestedReverseEval() const { return tapeInfos_.nestedReverseEval; }
-  FILE *tay_file() const { return tapeInfos_.tay_file; }
-  FILE *op_file() const { return tapeInfos_.op_file; }
-  FILE *val_file() const { return tapeInfos_.val_file; }
-  FILE *loc_file() const { return tapeInfos_.loc_file; }
-  void tay_file(FILE *file) { tapeInfos_.tay_file = file; }
-  void op_file(FILE *file) { tapeInfos_.op_file = file; }
-  void val_file(FILE *file) { tapeInfos_.val_file = file; }
-  void loc_file(FILE *file) { tapeInfos_.loc_file = file; }
-  unsigned char *opBuffer() const { return tapeInfos_.opBuffer; }
-  double *valBuffer() const { return tapeInfos_.valBuffer; }
-  size_t *locBuffer() const { return tapeInfos_.locBuffer; }
   double *signature() const { return tapeInfos_.signature; }
-  double *tayBuffer() const { return tapeInfos_.tayBuffer; }
-
-  void opBuffer(unsigned char *buffer) { tapeInfos_.opBuffer = buffer; }
-  void valBuffer(double *buffer) { tapeInfos_.valBuffer = buffer; }
-  void locBuffer(size_t *buffer) { tapeInfos_.locBuffer = buffer; }
   void signature(double *buffer) { tapeInfos_.signature = buffer; }
-  void tayBuffer(double *buffer) { tapeInfos_.tayBuffer = buffer; }
 
   void initTapeInfos_keep();
   // free all resources used by a tape before overwriting the tape
@@ -587,8 +539,7 @@ public:
   }
   // deletes the last (single) element (x) of the taylor buffer
   void delete_scaylor(size_t loc) {
-    --tapeInfos_.currTay;
-    globalTapeVars_.store[loc] = *tapeInfos_.currTay;
+    globalTapeVars_.store[loc] = tapeInfos_.tayBuffer_.retreatAndRead();
   }
 
   ///@brief returns current taylor coefficient and advances the stack pointer
@@ -626,7 +577,7 @@ public:
    *  - TayInfo is intentionally not part of this dispatch (different
    * lifecycle).
    */
-  template <InfoType<TapeInfos, ErrorType> Info> std::string_view fileName() {
+  template <InfoType<TapeInfos, ErrorType> Info> const char *fileName() {
     if constexpr (std::is_same_v<Info, OpInfoT>)
       return perTapeInfos_.op_fileName;
     else if constexpr (std::is_same_v<Info, LocInfoT>)
@@ -741,10 +692,9 @@ public:
         get_loc_block_f();
         numLocsForStats -= tapestats(Info::bufferSize);
       }
-      Info::setCurr(tapeInfos_,
-                    Info::bufferBegin(tapeInfos_) + numLocsForStats);
+      Info::setCurr(tapeInfos_, numLocsForStats);
     } else {
-      Info::setCurr(tapeInfos_, Info::bufferBegin(tapeInfos_));
+      Info::setCurr(tapeInfos_, 0);
     }
   }
 
@@ -796,7 +746,7 @@ public:
       }
     }
     Info::setNum(tapeInfos_, tapestats(Info::num) - lengthLB);
-    Info::setCurr(tapeInfos_, Info::bufferBegin(tapeInfos_) + lengthLB);
+    Info::setCurr(tapeInfos_, lengthLB);
   }
 
   /**

--- a/ADOL-C/src/valuetape/tapeinfos.cpp
+++ b/ADOL-C/src/valuetape/tapeinfos.cpp
@@ -8,93 +8,29 @@
 TapeInfos::TapeInfos(short tapeId) { tapeId_ = tapeId; }
 
 TapeInfos::~TapeInfos() {
-  if (op_file) {
-    fclose(op_file);
-    op_file = nullptr;
-  }
-  delete[] opBuffer;
-  opBuffer = nullptr;
-
-  if (val_file) {
-    fclose(val_file);
-    val_file = nullptr;
-  }
-
-  delete[] valBuffer;
-  valBuffer = nullptr;
-
-  if (loc_file) {
-    fclose(loc_file);
-    loc_file = nullptr;
-  }
-  delete[] locBuffer;
-  locBuffer = nullptr;
-
-  if (tay_file) {
-    fclose(tay_file);
-    tay_file = nullptr;
-  }
-
-  delete[] tayBuffer;
-  tayBuffer = nullptr;
-
   delete[] signature;
   signature = nullptr;
 }
 
 TapeInfos::TapeInfos(TapeInfos &&other) noexcept
-    : tapeId_(other.tapeId_), numInds(other.numInds), numDeps(other.numDeps),
-      keepTaylors(other.keepTaylors), op_file(other.op_file),
-      opBuffer(other.opBuffer), currOp(other.currOp), lastOpP1(other.lastOpP1),
-      numOps_Tape(other.numOps_Tape), num_eq_prod(other.num_eq_prod),
-      val_file(other.val_file), valBuffer(other.valBuffer),
-      currVal(other.currVal), lastValP1(other.lastValP1),
-      numVals_Tape(other.numVals_Tape), loc_file(other.loc_file),
-      locBuffer(other.locBuffer), currLoc(other.currLoc),
-      lastLocP1(other.lastLocP1), numLocs_Tape(other.numLocs_Tape),
-      tay_file(other.tay_file), tayBuffer(other.tayBuffer),
-      currTay(other.currTay), lastTayP1(other.lastTayP1),
-      numTays_Tape(other.numTays_Tape),
+    : opBuffer_(std::move(other.opBuffer_)),
+      valBuffer_(std::move(other.valBuffer_)),
+      locBuffer_(std::move(other.locBuffer_)),
+      tayBuffer_(std::move(other.tayBuffer_)), stats(other.stats),
+      tapeId_(other.tapeId_), numInds(other.numInds), numDeps(other.numDeps),
+      keepTaylors(other.keepTaylors), num_eq_prod(other.num_eq_prod),
       nextBufferNumber(other.nextBufferNumber),
       lastTayBlockInCore(other.lastTayBlockInCore), deg_save(other.deg_save),
       tay_numInds(other.tay_numInds), tay_numDeps(other.tay_numDeps),
       workMode(other.workMode), ext_diff_fct_index(other.ext_diff_fct_index),
       nestedReverseEval(other.nestedReverseEval),
       numSwitches(other.numSwitches), signature(other.signature) {
-  std::copy(std::begin(other.stats), std::end(other.stats), std::begin(stats));
-
-  // Null out source object's pointers
-  other.op_file = nullptr;
-  other.opBuffer = nullptr;
-  other.currOp = nullptr;
-  other.lastOpP1 = nullptr;
-
-  other.val_file = nullptr;
-  other.valBuffer = nullptr;
-  other.currVal = nullptr;
-  other.lastValP1 = nullptr;
-
-  other.loc_file = nullptr;
-  other.locBuffer = nullptr;
-  other.currLoc = nullptr;
-  other.lastLocP1 = nullptr;
-
-  other.tay_file = nullptr;
-  other.tayBuffer = nullptr;
-  other.currTay = nullptr;
-  other.lastTayP1 = nullptr;
-
   other.signature = nullptr;
 }
 
 TapeInfos &TapeInfos::operator=(TapeInfos &&other) noexcept {
   if (this != &other) {
     // Free existing resources to avoid leaks
-    delete[] opBuffer;
-    delete[] valBuffer;
-    delete[] locBuffer;
-    delete[] tayBuffer;
-
     delete[] signature;
 
     // **2. Move data members**
@@ -105,30 +41,11 @@ TapeInfos &TapeInfos::operator=(TapeInfos &&other) noexcept {
     std::copy(std::begin(other.stats), std::end(other.stats),
               std::begin(stats));
 
-    op_file = other.op_file;
-    opBuffer = other.opBuffer;
-    currOp = other.currOp;
-    lastOpP1 = other.lastOpP1;
-    numOps_Tape = other.numOps_Tape;
     num_eq_prod = other.num_eq_prod;
-
-    val_file = other.val_file;
-    valBuffer = other.valBuffer;
-    currVal = other.currVal;
-    lastValP1 = other.lastValP1;
-    numVals_Tape = other.numVals_Tape;
-
-    loc_file = other.loc_file;
-    locBuffer = other.locBuffer;
-    currLoc = other.currLoc;
-    lastLocP1 = other.lastLocP1;
-    numLocs_Tape = other.numLocs_Tape;
-
-    tay_file = other.tay_file;
-    tayBuffer = other.tayBuffer;
-    currTay = other.currTay;
-    lastTayP1 = other.lastTayP1;
-    numTays_Tape = other.numTays_Tape;
+    opBuffer_ = std::move(other.opBuffer_);
+    valBuffer_ = std::move(other.valBuffer_);
+    locBuffer_ = std::move(other.locBuffer_);
+    tayBuffer_ = std::move(other.tayBuffer_);
     nextBufferNumber = other.nextBufferNumber;
     lastTayBlockInCore = other.lastTayBlockInCore;
 
@@ -143,57 +60,16 @@ TapeInfos &TapeInfos::operator=(TapeInfos &&other) noexcept {
     signature = other.signature;
 
     // **3. Null out source object’s pointers to prevent double deletion**
-    other.op_file = nullptr;
-    other.opBuffer = nullptr;
-    other.currOp = nullptr;
-    other.lastOpP1 = nullptr;
-    other.val_file = nullptr;
-    other.valBuffer = nullptr;
-    other.currVal = nullptr;
-    other.lastValP1 = nullptr;
-    other.loc_file = nullptr;
-    other.locBuffer = nullptr;
-    other.currLoc = nullptr;
-    other.lastLocP1 = nullptr;
-    other.tay_file = nullptr;
-    other.tayBuffer = nullptr;
-    other.currTay = nullptr;
-    other.lastTayP1 = nullptr;
     other.signature = nullptr;
   }
   return *this;
 }
 
 void TapeInfos::freeTapeResources() {
-  delete[] opBuffer;
-  opBuffer = nullptr;
-
-  delete[] locBuffer;
-  locBuffer = nullptr;
-
-  delete[] valBuffer;
-  valBuffer = nullptr;
-
-  if (tayBuffer) {
-    delete[] tayBuffer;
-    tayBuffer = nullptr;
-  }
-  if (op_file) {
-    fclose(op_file);
-    op_file = nullptr;
-  }
-  if (loc_file) {
-    fclose(loc_file);
-    loc_file = nullptr;
-  }
-  if (val_file) {
-    fclose(val_file);
-    val_file = nullptr;
-  }
-  if (tay_file) {
-    fclose(tay_file);
-    tay_file = nullptr;
-  }
+  opBuffer_ = {};
+  valBuffer_ = {};
+  locBuffer_ = {};
+  tayBuffer_ = {};
   if (signature) {
     delete[] signature;
     signature = nullptr;
@@ -207,25 +83,21 @@ void TapeInfos::freeTapeResources() {
 /****************************************************************************/
 void TapeInfos::write_taylor(double *taylorCoefficientPos, std::ptrdiff_t keep,
                              const char *tay_fileName) {
-  double *i;
-  /* write data to buffer and put buffer to disk as long as data remain in
-   * the T-buffer => don't create an empty value stack buffer! */
-  while (currTay + keep > lastTayP1) {
-    for (i = currTay; i < lastTayP1; ++i) {
-      *i = *taylorCoefficientPos;
-      /* In this assignment the precision will be sacrificed if the type
-       * double is defined as float. */
+  while (tayBuffer_.position() > tayBuffer_.capacity() - keep) {
+    for (auto i = tayBuffer_.position(); i < tayBuffer_.capacity(); ++i) {
+      tayBuffer_[i] = *taylorCoefficientPos;
       ++taylorCoefficientPos;
     }
-    keep -= lastTayP1 - currTay;
-    put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName, lastTayP1);
+    keep -= tayBuffer_.remainingCapacity();
+    put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName,
+                                             tayBuffer_.capacity());
   }
 
-  for (i = currTay; i < currTay + keep; ++i) {
-    *i = *taylorCoefficientPos;
+  for (int i = 0; i < keep; ++i) {
+    tayBuffer_[i + tayBuffer_.position()] = *taylorCoefficientPos;
     ++taylorCoefficientPos;
   }
-  currTay += keep;
+  tayBuffer_.position(tayBuffer_.position() + keep);
 }
 
 void TapeInfos::write_taylors(double *taylorCoefficientPos, int keep,
@@ -233,11 +105,11 @@ void TapeInfos::write_taylors(double *taylorCoefficientPos, int keep,
                               const char *tay_fileName) {
   for (int j = 0; j < numDir; ++j) {
     for (int i = 0; i < keep; ++i) {
-      if (currTay == lastTayP1)
-        put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName, lastTayP1);
+      if (tayBuffer_.position() == tayBuffer_.capacity())
+        put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName,
+                                                 tayBuffer_.capacity());
 
-      *currTay = *taylorCoefficientPos;
-      ++currTay;
+      tayBuffer_.writeAndAdvance(*taylorCoefficientPos);
       ++taylorCoefficientPos;
     }
     if (degree > keep)
@@ -248,41 +120,39 @@ void TapeInfos::write_taylors(double *taylorCoefficientPos, int keep,
 void TapeInfos::write_scaylors(const double *taylorCoefficientPos,
                                std::ptrdiff_t size, const char *tay_fileName) {
   size_t pos = 0;
-  std::span<double> taySpan(currTay, lastTayP1);
-  /* write data to buffer and put buffer to disk as long as data remain in
-   * the x-buffer => don't create an empty value stack buffer! */
-  while (currTay + size > lastTayP1) {
+  while (tayBuffer_.position() > tayBuffer_.capacity() - size) {
+    std::span<double> taySpan(tayBuffer_.current(),
+                              tayBuffer_.begin() + tayBuffer_.capacity());
     for (double &tay : taySpan) {
       tay = taylorCoefficientPos[pos++];
     }
-    size -= lastTayP1 - currTay;
-    put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName, lastTayP1);
+    size -= tayBuffer_.remainingCapacity();
+    put_block<TayInfo<TapeInfos, ErrorType>>(tay_fileName,
+                                             tayBuffer_.capacity());
   }
 
-  std::span<double> tayBufferSpan(currTay, tayBuffer + size);
+  std::span<double> tayBufferSpan(tayBuffer_.current(),
+                                  tayBuffer_.current() + size);
   for (double &tay : tayBufferSpan) {
     tay = taylorCoefficientPos[pos++];
   }
-  currTay += size;
+  tayBuffer_.position(tayBuffer_.position() + size);
 }
 
 void TapeInfos::get_taylors(double *taylorCoefficients, std::ptrdiff_t degree) {
   double *T = taylorCoefficients + degree;
-  std::span<double> taySpan(currTay, tayBuffer);
-  /* As long as all values from the taylor stack buffer will be used copy
-   * them into the taylor buffer and load the next (previous) buffer. */
-  while (currTay - degree < tayBuffer) {
+  while (tayBuffer_.position() < static_cast<size_t>(degree)) {
+    std::span<double> taySpan(tayBuffer_.begin(), tayBuffer_.current());
     for (auto tay = taySpan.rbegin(); tay != taySpan.rend(); tay++) {
       *(T--) = *tay;
     }
-    degree -= currTay - tayBuffer;
+    degree -= tayBuffer_.position();
     get_tay_block_r();
   }
 
   /* Copy the remaining values from the stack into the buffer ... */
   for (int j = 0; j < degree; ++j) {
-    --currTay;
-    *(--T) = *currTay;
+    *(--T) = tayBuffer_.retreatAndRead();
   }
 }
 
@@ -293,22 +163,21 @@ void TapeInfos::get_taylors_p(double *taylorCoefficients, int degree,
   /* update the directions except the base point parts */
   for (int j = 0; j < numDir; ++j) {
     for (int i = 1; i < degree; ++i) {
-      if (currTay == tayBuffer)
+      if (tayBuffer_.position() == 0)
         get_tay_block_r();
 
-      --currTay;
       --T;
-      *T = *currTay;
+      *T = tayBuffer_.retreatAndRead();
     }
     --T; /* skip the base point part */
   }
   /* now update the base point parts */
-  if (currTay == tayBuffer)
+  if (tayBuffer_.position() == 0)
     get_tay_block_r();
 
-  --currTay;
+  tayBuffer_.retreat();
   for (int i = 0; i < numDir; ++i) {
-    *T = *currTay;
+    *T = *tayBuffer_.current();
     T += degree;
   }
 }
@@ -323,7 +192,7 @@ void TapeInfos::get_tay_block_r() {
 
   lastTayBlockInCore = 0;
   const size_t number = stats[TapeInfos::TAY_BUFFER_SIZE];
-  if (fseek(tay_file,
+  if (fseek(tayBuffer_.file(),
             static_cast<long>(sizeof(double) * nextBufferNumber * number),
             SEEK_SET) == -1)
     ADOLCError::fail(ADOLCError::ErrorType::EVAL_SEEK_VALUE_STACK,
@@ -333,20 +202,20 @@ void TapeInfos::get_tay_block_r() {
   const size_t chunks = number / chunkSize;
 
   for (size_t i = 0; i < chunks; ++i)
-    if (fread(tayBuffer + i * chunkSize, chunkSize * sizeof(double), 1,
-              tay_file) != 1) {
+    if (fread(tayBuffer_.begin() + i * chunkSize, chunkSize * sizeof(double), 1,
+              tayBuffer_.file()) != 1) {
       ADOLCError::fail(ADOLCError::ErrorType::TAPING_FATAL_IO_ERROR,
                        CURRENT_LOCATION);
     }
   const int remain = number % chunkSize;
   if (remain != 0)
-    if (fread(tayBuffer + chunks * chunkSize, remain * sizeof(double), 1,
-              tay_file) != 1) {
+    if (fread(tayBuffer_.begin() + chunks * chunkSize, remain * sizeof(double),
+              1, tayBuffer_.file()) != 1) {
       ADOLCError::fail(ADOLCError::ErrorType::TAPING_FATAL_IO_ERROR,
                        CURRENT_LOCATION);
     }
 
-  currTay = lastTayP1;
+  tayBuffer_.position(tayBuffer_.capacity());
   --nextBufferNumber;
 }
 /**
@@ -360,22 +229,22 @@ void TapeInfos::get_loc_block_f() {
   size_t i, chunks;
   size_t number, remain, chunkSize;
 
-  number = MIN_ADOLC(stats[TapeInfos::LOC_BUFFER_SIZE], numLocs_Tape);
+  number = MIN_ADOLC(stats[TapeInfos::LOC_BUFFER_SIZE], locBuffer_.numOnTape());
   chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(size_t);
   chunks = number / chunkSize;
   for (i = 0; i < chunks; ++i)
-    if (fread(locBuffer + i * chunkSize, chunkSize * sizeof(size_t), 1,
-              loc_file) != 1)
+    if (fread(locBuffer_.begin() + i * chunkSize, chunkSize * sizeof(size_t), 1,
+              locBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_LOC_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
   remain = number % chunkSize;
   if (remain != 0)
-    if (fread(locBuffer + chunks * chunkSize, remain * sizeof(size_t), 1,
-              loc_file) != 1)
+    if (fread(locBuffer_.begin() + chunks * chunkSize, remain * sizeof(size_t),
+              1, locBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_LOC_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
-  numLocs_Tape -= number;
-  currLoc = locBuffer;
+  locBuffer_.numOnTape(locBuffer_.numOnTape() - number);
+  locBuffer_.position(0);
 }
 
 /****************************************************************************/
@@ -387,24 +256,27 @@ void TapeInfos::get_loc_block_r() {
   const size_t chunks = number / chunkSize;
   const size_t remain = number % chunkSize;
 
-  fseek(loc_file, static_cast<long>(sizeof(size_t) * (numLocs_Tape - number)),
+  fseek(locBuffer_.file(),
+        static_cast<long>(sizeof(size_t) * (locBuffer_.numOnTape() - number)),
         SEEK_SET);
   for (size_t i = 0; i < chunks; ++i) {
-    if (fread(locBuffer + i * chunkSize, chunkSize * sizeof(size_t), 1,
-              loc_file) != 1)
+    if (fread(locBuffer_.begin() + i * chunkSize, chunkSize * sizeof(size_t), 1,
+              locBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_LOC_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
   }
 
   if (remain != 0) {
-    if (fread(locBuffer + chunks * chunkSize, remain * sizeof(size_t), 1,
-              loc_file) != 1) {
+    if (fread(locBuffer_.begin() + chunks * chunkSize, remain * sizeof(size_t),
+              1, locBuffer_.file()) != 1) {
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_LOC_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
     }
   }
-  numLocs_Tape -= stats[TapeInfos::LOC_BUFFER_SIZE];
-  currLoc = lastLocP1 - *(lastLocP1 - 1);
+  locBuffer_.numOnTape(locBuffer_.numOnTape() -
+                       stats[TapeInfos::LOC_BUFFER_SIZE]);
+  locBuffer_.position(locBuffer_.capacity() -
+                      locBuffer_[locBuffer_.capacity() - 1]);
 }
 
 /**
@@ -422,49 +294,48 @@ void TapeInfos::put_op(OPCODES op, const char *loc_fileName,
   using ADOLC::detail::ValInfo;
   using ADOLCError::ErrorType;
   /* make sure we have enough slots to write the locs */
-  if (currLoc + maxLocsPerOp + reserveExtraLocations > lastLocP1) {
-    std::ptrdiff_t remainder = lastLocP1 - currLoc;
+  if (locBuffer_.position() >
+      locBuffer_.capacity() - maxLocsPerOp - reserveExtraLocations) {
+    const size_t remainder = locBuffer_.remainingCapacity();
     if (remainder > 0)
-      std::memset(currLoc, 0, (remainder - 1) * sizeof(size_t));
-    *(lastLocP1 - 1) = remainder;
-    put_block<LocInfo<TapeInfos, ErrorType>>(loc_fileName, lastLocP1);
+      std::memset(locBuffer_.current(), 0, (remainder - 1) * sizeof(size_t));
+    locBuffer_[locBuffer_.capacity() - 1] = remainder;
+    put_block<LocInfo<TapeInfos, ErrorType>>(loc_fileName,
+                                             locBuffer_.capacity());
     /* every operation writes 1 opcode */
-    if (currOp + 1 == lastOpP1) {
-      *currOp = end_of_op;
-      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, lastOpP1);
-      *currOp = end_of_op;
-      ++currOp;
+    if (opBuffer_.position() == opBuffer_.capacity() - 1) {
+      opBuffer_.writeCurrent(static_cast<unsigned char>(end_of_op));
+      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName,
+                                              opBuffer_.capacity());
+      opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_op));
     }
-    *currOp = end_of_int;
-    ++currOp;
+    opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_int));
   }
   /* every operation writes <5 values --- 3 should be sufficient */
-  if (currVal + 5 > lastValP1) {
-    size_t valRemainder = lastValP1 - currVal;
+  if (valBuffer_.position() > valBuffer_.capacity() - 5) {
+    const size_t valRemainder = valBuffer_.remainingCapacity();
     put_loc(valRemainder);
     /* avoid writing uninitialized memory to the file and get valgrind upset
      */
-    std::memset(currVal, 0, valRemainder * sizeof(double));
-    put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName, lastValP1);
+    std::memset(valBuffer_.current(), 0, valRemainder * sizeof(double));
+    put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName,
+                                             valBuffer_.capacity());
     /* every operation writes 1 opcode */
-    if (currOp + 1 == lastOpP1) {
-      *currOp = end_of_op;
-      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, lastOpP1);
-      *currOp = end_of_op;
-      ++currOp;
+    if (opBuffer_.position() == opBuffer_.capacity() - 1) {
+      opBuffer_.writeCurrent(static_cast<unsigned char>(end_of_op));
+      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName,
+                                              opBuffer_.capacity());
+      opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_op));
     }
-    *currOp = end_of_val;
-    ++currOp;
+    opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_val));
   }
   /* every operation writes 1 opcode */
-  if (currOp + 1 == lastOpP1) {
-    *currOp = end_of_op;
-    put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, lastOpP1);
-    *currOp = end_of_op;
-    ++currOp;
+  if (opBuffer_.position() == opBuffer_.capacity() - 1) {
+    opBuffer_.writeCurrent(static_cast<unsigned char>(end_of_op));
+    put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, opBuffer_.capacity());
+    opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_op));
   }
-  *currOp = static_cast<unsigned char>(op);
-  ++currOp;
+  opBuffer_.writeAndAdvance(static_cast<unsigned char>(op));
 }
 
 /****************************************************************************/
@@ -474,22 +345,22 @@ void TapeInfos::get_op_block_f() {
   size_t i, chunks;
   size_t number, remain, chunkSize;
 
-  number = MIN_ADOLC(stats[TapeInfos::OP_BUFFER_SIZE], numOps_Tape);
+  number = MIN_ADOLC(stats[TapeInfos::OP_BUFFER_SIZE], opBuffer_.numOnTape());
   chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(unsigned char);
   chunks = number / chunkSize;
   for (i = 0; i < chunks; ++i)
-    if (fread(opBuffer + i * chunkSize, chunkSize * sizeof(unsigned char), 1,
-              op_file) != 1)
+    if (fread(opBuffer_.begin() + i * chunkSize,
+              chunkSize * sizeof(unsigned char), 1, opBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_OP_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
   remain = number % chunkSize;
   if (remain != 0)
-    if (fread(opBuffer + chunks * chunkSize, remain * sizeof(unsigned char), 1,
-              op_file) != 1)
+    if (fread(opBuffer_.begin() + chunks * chunkSize,
+              remain * sizeof(unsigned char), 1, opBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_OP_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
-  numOps_Tape -= remain;
-  currOp = opBuffer;
+  opBuffer_.numOnTape(opBuffer_.numOnTape() - remain);
+  opBuffer_.position(0);
 }
 
 /****************************************************************************/
@@ -500,26 +371,27 @@ void TapeInfos::get_op_block_r() {
   size_t number, remain, chunkSize;
 
   number = stats[TapeInfos::OP_BUFFER_SIZE];
-  fseek(op_file,
-        static_cast<long>(sizeof(unsigned char) * (numOps_Tape - number)),
+  fseek(opBuffer_.file(),
+        static_cast<long>(sizeof(unsigned char) *
+                          (opBuffer_.numOnTape() - number)),
         SEEK_SET);
   chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(unsigned char);
   chunks = number / chunkSize;
   for (i = 0; i < chunks; ++i)
-    if (fread(opBuffer + i * chunkSize, chunkSize * sizeof(unsigned char), 1,
-              op_file) != 1)
+    if (fread(opBuffer_.begin() + i * chunkSize,
+              chunkSize * sizeof(unsigned char), 1, opBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_OP_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
 
   remain = number % chunkSize;
   if (remain != 0)
-    if (fread(opBuffer + chunks * chunkSize, remain * sizeof(unsigned char), 1,
-              op_file) != 1)
+    if (fread(opBuffer_.begin() + chunks * chunkSize,
+              remain * sizeof(unsigned char), 1, opBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_OP_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
 
-  numOps_Tape -= number;
-  currOp = opBuffer + number;
+  opBuffer_.numOnTape(opBuffer_.numOnTape() - number);
+  opBuffer_.position(number);
 }
 
 /**
@@ -539,20 +411,17 @@ void TapeInfos::put_vals_writeBlock(double *vals, size_t numVals,
   using ADOLC::detail::ValInfo;
   using ADOLCError::ErrorType;
   for (size_t i = 0; i < numVals; ++i) {
-    *currVal = vals[i];
-    ++currVal;
+    valBuffer_.writeAndAdvance(vals[i]);
   }
-  put_loc(lastValP1 - currVal);
-  put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName, lastTayP1);
+  put_loc(valBuffer_.capacity() - valBuffer_.position());
+  put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName, valBuffer_.capacity());
   /* every operation writes 1 opcode */
-  if (currOp + 1 == lastOpP1) {
-    *currOp = end_of_op;
-    put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, lastOpP1);
-    *currOp = end_of_op;
-    ++currOp;
+  if (opBuffer_.position() == opBuffer_.capacity() - 1) {
+    opBuffer_.writeCurrent(static_cast<unsigned char>(end_of_op));
+    put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, opBuffer_.capacity());
+    opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_op));
   }
-  *currOp = end_of_val;
-  ++currOp;
+  opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_val));
 }
 
 /****************************************************************************/
@@ -562,25 +431,25 @@ void TapeInfos::get_val_block_f() {
   size_t i, chunks;
   size_t number, remain, chunkSize;
 
-  number = MIN_ADOLC(stats[TapeInfos::VAL_BUFFER_SIZE], numVals_Tape);
+  number = MIN_ADOLC(stats[TapeInfos::VAL_BUFFER_SIZE], valBuffer_.numOnTape());
   chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(double);
   chunks = number / chunkSize;
   for (i = 0; i < chunks; ++i)
-    if (fread(valBuffer + i * chunkSize, chunkSize * sizeof(double), 1,
-              val_file) != 1)
+    if (fread(valBuffer_.begin() + i * chunkSize, chunkSize * sizeof(double), 1,
+              valBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
 
   remain = number % chunkSize;
   if (remain != 0)
-    if (fread(valBuffer + chunks * chunkSize, remain * sizeof(double), 1,
-              val_file) != 1)
+    if (fread(valBuffer_.begin() + chunks * chunkSize, remain * sizeof(double),
+              1, valBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
-  numVals_Tape -= number;
-  currVal = valBuffer;
+  valBuffer_.numOnTape(valBuffer_.numOnTape() - number);
+  valBuffer_.position(0);
   /* get_size_t_f(); value used in reverse only */
-  ++currLoc;
+  locBuffer_.advance();
 }
 
 /****************************************************************************/
@@ -592,25 +461,25 @@ void TapeInfos::get_val_block_r() {
   size_t temp;
 
   number = stats[TapeInfos::VAL_BUFFER_SIZE];
-  fseek(val_file, static_cast<long>(sizeof(double) * (numVals_Tape - number)),
+  fseek(valBuffer_.file(),
+        static_cast<long>(sizeof(double) * (valBuffer_.numOnTape() - number)),
         SEEK_SET);
   chunkSize = ADOLC_IO_CHUNK_SIZE / sizeof(double);
   chunks = number / chunkSize;
   for (i = 0; i < chunks; ++i)
-    if (fread(valBuffer + i * chunkSize, chunkSize * sizeof(double), 1,
-              val_file) != 1)
+    if (fread(valBuffer_.begin() + i * chunkSize, chunkSize * sizeof(double), 1,
+              valBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
   remain = number % chunkSize;
   if (remain != 0)
-    if (fread(valBuffer + chunks * chunkSize, remain * sizeof(double), 1,
-              val_file) != 1)
+    if (fread(valBuffer_.begin() + chunks * chunkSize, remain * sizeof(double),
+              1, valBuffer_.file()) != 1)
       ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                        CURRENT_LOCATION);
-  numVals_Tape -= number;
-  --currLoc;
-  temp = *currLoc;
-  currVal = lastValP1 - temp;
+  valBuffer_.numOnTape(valBuffer_.numOnTape() - number);
+  temp = locBuffer_.retreatAndRead();
+  valBuffer_.position(valBuffer_.capacity() - temp);
 }
 
 /****************************************************************************/
@@ -624,18 +493,18 @@ size_t TapeInfos::get_val_space(const char *op_fileName,
   using ADOLC::detail::ValInfo;
   using ADOLCError::ErrorType;
 
-  if (lastValP1 - 5 < currVal) {
-    put_loc(lastValP1 - currVal);
-    put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName, lastValP1);
+  if (valBuffer_.position() > valBuffer_.capacity() - 5) {
+    put_loc(valBuffer_.remainingCapacity());
+    put_block<ValInfo<TapeInfos, ErrorType>>(val_fileName,
+                                             valBuffer_.capacity());
     /* every operation writes 1 opcode */
-    if (currOp + 1 == lastOpP1) {
-      *currOp = end_of_op;
-      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName, lastOpP1);
-      *currOp = end_of_op;
-      ++currOp;
+    if (opBuffer_.position() == opBuffer_.capacity() - 1) {
+      opBuffer_.writeCurrent(static_cast<unsigned char>(end_of_op));
+      put_block<OpInfo<TapeInfos, ErrorType>>(op_fileName,
+                                              opBuffer_.capacity());
+      opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_op));
     }
-    *currOp = end_of_val;
-    ++currOp;
+    opBuffer_.writeAndAdvance(static_cast<unsigned char>(end_of_val));
   }
-  return (lastValP1 - currVal);
+  return (valBuffer_.remainingCapacity());
 }

--- a/ADOL-C/src/valuetape/valuetape.cpp
+++ b/ADOL-C/src/valuetape/valuetape.cpp
@@ -18,34 +18,37 @@ ValueTape::~ValueTape() {
 
 void ValueTape::initTapeInfos_keep() {
   // we want to keep the buffers
-  unsigned char *opBuffer = tapeInfos_.opBuffer;
-  size_t *locBuffer = tapeInfos_.locBuffer;
-  double *valBuffer = tapeInfos_.valBuffer;
-  double *tayBuffer = tapeInfos_.tayBuffer;
+  const size_t opBufferCapacity = tapeInfos_.opBuffer_.capacity();
+  unsigned char *const opBuffer = tapeInfos_.opBuffer_.releaseBuffer();
+
+  const size_t valBufferCapacity = tapeInfos_.valBuffer_.capacity();
+  double *const valBuffer = tapeInfos_.valBuffer_.releaseBuffer();
+
+  const size_t locBufferCapacity = tapeInfos_.locBuffer_.capacity();
+  size_t *const locBuffer = tapeInfos_.locBuffer_.releaseBuffer();
+
+  const size_t tayBufferCapacity = tapeInfos_.tayBuffer_.capacity();
+  double *const tayBuffer = tapeInfos_.tayBuffer_.releaseBuffer();
+  FILE *const tay_file = tapeInfos_.tayBuffer_.releaseFile();
+
   double *signature = tapeInfos_.signature;
-  FILE *tay_file = tapeInfos_.tay_file;
   short tapeId = tapeInfos_.tapeId_;
 
   // keep the stats to later know the number of indeps, etc...
   auto tmp_stats = tapeInfos_.stats;
 
   // make sure the destructor will not destroy them
-  tapeInfos_.opBuffer = nullptr;
-  tapeInfos_.locBuffer = nullptr;
-  tapeInfos_.valBuffer = nullptr;
-  tapeInfos_.tayBuffer = nullptr;
   tapeInfos_.signature = nullptr;
-  tapeInfos_.tay_file = nullptr;
 
   tapeInfos_ = TapeInfos();
   tapeInfos_.stats = tmp_stats;
 
-  tapeInfos_.opBuffer = opBuffer;
-  tapeInfos_.locBuffer = locBuffer;
-  tapeInfos_.valBuffer = valBuffer;
-  tapeInfos_.tayBuffer = tayBuffer;
+  tapeInfos_.opBuffer_.resetBuffer(opBuffer, opBufferCapacity);
+  tapeInfos_.valBuffer_.resetBuffer(valBuffer, valBufferCapacity);
+  tapeInfos_.locBuffer_.resetBuffer(locBuffer, locBufferCapacity);
+  tapeInfos_.tayBuffer_.resetBuffer(tayBuffer, tayBufferCapacity);
+  tapeInfos_.tayBuffer_.resetFile(tay_file);
   tapeInfos_.signature = signature;
-  tapeInfos_.tay_file = tay_file;
   tapeInfos_.tapeId_ = tapeId;
 }
 
@@ -61,8 +64,8 @@ int ValueTape::initNewTape() {
     fail(TAPING_TAPE_STILL_IN_USE, CURRENT_LOCATION,
          FailInfo{.info1 = tapeId()});
   }
-  if (tay_file())
-    rewind(tay_file());
+  if (tapeInfos_.tayBuffer_.file() != nullptr)
+    rewind(tapeInfos_.tayBuffer_.file());
 
   // creates new tapeInfos object with old buffers
   // thus, we dont allocate the buffers again if they are already existent
@@ -97,8 +100,8 @@ void ValueTape::openTape() {
   } else if (keepTaylors() == 0 && tapestats(TapeInfos::OP_FILE_ACCESS) == 1 &&
              tapestats(TapeInfos::LOC_FILE_ACCESS) == 1 &&
              tapestats(TapeInfos::VAL_FILE_ACCESS) == 1) {
-    if (tay_file())
-      rewind(tay_file());
+    if (tapeInfos_.tayBuffer_.file() != nullptr)
+      rewind(tapeInfos_.tayBuffer_.file());
     initTapeInfos_keep();
     read_tape_stats();
   }
@@ -159,7 +162,7 @@ size_t ValueTape::keep_stock() {
   put_loc(0);    /* lowest loc */
   put_loc(loc2); /* highest loc */
 
-  tapeInfos_.numTays_Tape += globalTapeVars_.storeSize;
+  add_numTays_Tape(globalTapeVars_.storeSize);
   /* now really do it if keepTaylors is set */
   if (tapeInfos_.keepTaylors) {
     do {
@@ -177,7 +180,7 @@ void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
   using ADOLCError::FailInfo;
   using ADOLCError::ErrorType::TAPING_TBUFFER_ALLOCATION_FAILED;
 
-  if (tayBuffer()) {
+  if (tapeInfos_.tayBuffer_.begin()) {
 #if defined(ADOLC_DEBUG)
     fprintf(DIAG_OUT,
             "\nADOL-C warning: !!! Taylor information for tape %d"
@@ -188,15 +191,14 @@ void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
   } else {
     if (tay_fileName() == nullptr)
       tay_fileName();
-    tayBuffer(new double[bufferSize]);
+    tapeInfos_.tayBuffer_.allocIfNull(bufferSize);
   }
 
   deg_save(degreeSave);
   if (degreeSave >= 0)
     keepTaylors(1);
-  currTay(tayBuffer());
-  lastTayP1(currTay() + bufferSize);
-  numTays_Tape(0);
+  tapeInfos_.tayBuffer_.position(0);
+  tapeInfos_.tayBuffer_.numOnTape(0);
 }
 
 /****************************************************************************/
@@ -205,24 +207,23 @@ void ValueTape::taylor_begin(size_t bufferSize, int degreeSave) {
 void ValueTape::finish_tay_file() {
   /* enforces failure of reverse => retaping */
   deg_save(-1);
-  if (tay_file()) {
-    fclose(tay_file());
+  if (tapeInfos_.tayBuffer_.file() != nullptr) {
+    tapeInfos_.tayBuffer_.closeFile();
     remove(tay_fileName());
-    tay_file(nullptr);
   }
   return;
 }
 
 void ValueTape::taylor_close() {
-  if (tay_file()) {
+  if (tapeInfos_.tayBuffer_.file() != nullptr) {
     if (keepTaylors())
       tapeInfos_.put_block<TayInfo<TapeInfos, ErrorType>>(
-          perTapeInfos_.tay_fileName, currTay());
+          perTapeInfos_.tay_fileName, tapeInfos_.tayBuffer_.position());
   } else {
-    numTays_Tape(currTay() - tayBuffer());
+    tapeInfos_.tayBuffer_.numOnTape(tapeInfos_.tayBuffer_.position());
   }
   lastTayBlockInCore(1);
-  tapestats(TapeInfos::NUM_TAYS, numTays_Tape());
+  tapestats(TapeInfos::NUM_TAYS, tapeInfos_.tayBuffer_.numOnTape());
   tay_numInds(tapestats(TapeInfos::NUM_INDEPENDENTS));
   tay_numDeps(tapestats(TapeInfos::NUM_DEPENDENTS));
 }
@@ -231,19 +232,21 @@ void ValueTape::taylor_close() {
 /* Initializes a reverse sweep.                                             */
 /****************************************************************************/
 void ValueTape::taylor_back() {
-  if (tayBuffer() == nullptr)
+  if (tapeInfos_.tayBuffer_.begin() == nullptr)
     ADOLCError::fail(ADOLCError::ErrorType::REVERSE_NO_TAYLOR_STACK,
                      CURRENT_LOCATION, ADOLCError::FailInfo{.info1 = tapeId()});
 
-  nextBufferNumber(numTays_Tape() / tapestats(TapeInfos::TAY_BUFFER_SIZE));
-  const size_t number = numTays_Tape() % tapestats(TapeInfos::TAY_BUFFER_SIZE);
-  currTay(tayBuffer() + number);
+  nextBufferNumber(tapeInfos_.tayBuffer_.numOnTape() /
+                   tapestats(TapeInfos::TAY_BUFFER_SIZE));
+  const size_t number =
+      tapeInfos_.tayBuffer_.numOnTape() % tapestats(TapeInfos::TAY_BUFFER_SIZE);
+  tapeInfos_.tayBuffer_.position(number);
 
   if (lastTayBlockInCore() != 1) {
-    if (!tay_file())
+    if (tapeInfos_.tayBuffer_.file() == nullptr)
       ADOLCError::fail(ADOLCError::ErrorType::TAY_NULLPTR, CURRENT_LOCATION);
 
-    if (fseek(tay_file(),
+    if (fseek(tapeInfos_.tayBuffer_.file(),
               static_cast<long>(sizeof(double) * nextBufferNumber() *
                                 tapestats(TapeInfos::TAY_BUFFER_SIZE)),
               SEEK_SET) == -1)
@@ -254,16 +257,17 @@ void ValueTape::taylor_back() {
     const size_t chunks = number / chunkSize;
 
     for (size_t i = 0; i < chunks; ++i)
-      if (fread(tayBuffer() + i * chunkSize, chunkSize * sizeof(double), 1,
-                tay_file()) != 1)
+      if (fread(tapeInfos_.tayBuffer_.begin() + i * chunkSize,
+                chunkSize * sizeof(double), 1,
+                tapeInfos_.tayBuffer_.file()) != 1)
         ADOLCError::fail(ADOLCError::ErrorType::TAPING_FATAL_IO_ERROR,
                          CURRENT_LOCATION);
 
     const size_t remain = number % chunkSize;
 
     if (remain != 0)
-      if (fread(tayBuffer() + chunks * chunkSize, remain * sizeof(double), 1,
-                tay_file()) != 1)
+      if (fread(tapeInfos_.tayBuffer_.begin() + chunks * chunkSize,
+                remain * sizeof(double), 1, tapeInfos_.tayBuffer_.file()) != 1)
         ADOLCError::fail(ADOLCError::ErrorType::TAPING_FATAL_IO_ERROR,
                          CURRENT_LOCATION);
   }
@@ -277,22 +281,9 @@ void ValueTape::taylor_back() {
 /****************************************************************************/
 
 void ValueTape::initTapeBuffers() {
-  if (!opBuffer())
-    opBuffer(new unsigned char[tapestats(TapeInfos::OP_BUFFER_SIZE)]);
-
-  if (!locBuffer())
-    locBuffer(new size_t[tapestats(TapeInfos::LOC_BUFFER_SIZE)]);
-
-  if (!valBuffer())
-    valBuffer(new double[tapestats(TapeInfos::VAL_BUFFER_SIZE)]);
-
-  if (!opBuffer() || !locBuffer() || !valBuffer())
-    ADOLCError::fail(ADOLCError::ErrorType::TAPING_BUFFER_ALLOCATION_FAILED,
-                     CURRENT_LOCATION);
-
-  lastOpP1(opBuffer() + tapestats(TapeInfos::OP_BUFFER_SIZE));
-  lastLocP1(locBuffer() + tapestats(TapeInfos::LOC_BUFFER_SIZE));
-  lastValP1(valBuffer() + tapestats(TapeInfos::VAL_BUFFER_SIZE));
+  tapeInfos_.opBuffer_.allocIfNull(tapestats(TapeInfos::OP_BUFFER_SIZE));
+  tapeInfos_.valBuffer_.allocIfNull(tapestats(TapeInfos::VAL_BUFFER_SIZE));
+  tapeInfos_.locBuffer_.allocIfNull(tapestats(TapeInfos::LOC_BUFFER_SIZE));
 }
 
 /****************************************************************************/
@@ -303,9 +294,9 @@ void ValueTape::initTapeBuffers() {
 void ValueTape::start_trace() {
   initTapeBuffers();
   // reset the position pointer to first entry
-  currOp(opBuffer());
-  currLoc(locBuffer());
-  currVal(valBuffer());
+  tapeInfos_.opBuffer_.position(0);
+  tapeInfos_.locBuffer_.position(0);
+  tapeInfos_.valBuffer_.position(0);
 
   num_eq_prod(0);
   numSwitches(0);
@@ -344,22 +335,22 @@ void ValueTape::save_params() {
            tapestats(TapeInfos::NUM_PARAM) * sizeof(double));
 
   free_all_taping_params();
-  if (currVal() + tapestats(TapeInfos::NUM_PARAM) < lastValP1())
+  if (tapeInfos_.valBuffer_.position() <
+      tapeInfos_.valBuffer_.capacity() - tapestats(TapeInfos::NUM_PARAM))
     put_vals_notWriteBlock(paramstore(), tapestats(TapeInfos::NUM_PARAM));
-
   else {
     size_t np = tapestats(TapeInfos::NUM_PARAM);
     size_t ip = 0;
     size_t remain = tapestats(TapeInfos::NUM_PARAM);
     while (tapestats(TapeInfos::NUM_PARAM) > ip) {
       remain = tapestats(TapeInfos::NUM_PARAM) - ip;
-      const size_t avail = lastValP1() - currVal();
+      const size_t avail = tapeInfos_.valBuffer_.remainingCapacity();
       const size_t chunk = (avail < remain) ? avail : remain;
       put_vals_notWriteBlock(paramstore() + ip, chunk);
       ip += chunk;
       if (ip < np)
         tapeInfos_.put_block<ValInfo<TapeInfos, ErrorType>>(
-            perTapeInfos_.val_fileName, lastValP1());
+            perTapeInfos_.val_fileName, tapeInfos_.valBuffer_.capacity());
     }
   }
 }
@@ -380,15 +371,15 @@ void ValueTape::stop_trace(int flag) {
   if (keepTaylors())
     taylor_close();
 
-  tapestats(TapeInfos::NUM_TAYS, numTays_Tape());
+  tapestats(TapeInfos::NUM_TAYS, tapeInfos_.tayBuffer_.numOnTape());
 
   /* The taylor stack size base estimation results in a doubled taylor count
    * if we tape with keep (taylors counted in adouble.cpp/avector.cpp and
    * "keep_stock" even if not written and a second time when actually
    * written by "put_tay_block"). Correction follows here. */
-  if (keepTaylors() != 0 && tay_file()) {
+  if (keepTaylors() != 0 && tapeInfos_.tayBuffer_.file() != nullptr) {
     tapestats(TapeInfos::NUM_TAYS, tapestats(TapeInfos::NUM_TAYS) / 2);
-    numTays_Tape(numTays_Tape() / 2);
+    tapeInfos_.tayBuffer_.numOnTape(tapeInfos_.tayBuffer_.numOnTape() / 2);
   }
 
   close_tape(flag); /* closes the tape, files up stats, and writes the
@@ -400,61 +391,51 @@ void ValueTape::stop_trace(int flag) {
 /****************************************************************************/
 void ValueTape::close_tape(int flag) {
   /* finish operations tape, close it, update stats */
-  if (flag != 0 || op_file()) {
-    if (currOp() != opBuffer()) {
+  if (flag != 0 || (tapeInfos_.opBuffer_.file() != nullptr)) {
+    if (tapeInfos_.opBuffer_.position() > 0) {
       tapeInfos_.put_block<OpInfo<TapeInfos, ErrorType>>(
-          perTapeInfos_.op_fileName, currOp());
-    }
-    if (op_file()) {
-      fclose(op_file());
-      op_file(nullptr);
+          perTapeInfos_.op_fileName, tapeInfos_.opBuffer_.position());
     }
     tapestats(TapeInfos::OP_FILE_ACCESS, 1);
-    delete[] opBuffer();
-    opBuffer(nullptr);
+    tapeInfos_.opBuffer_.closeFile();
+    delete[] tapeInfos_.opBuffer_.releaseBuffer();
   } else {
-    numOps_Tape(currOp() - opBuffer());
+    tapeInfos_.opBuffer_.numOnTape(tapeInfos_.opBuffer_.position());
   }
-  tapestats(TapeInfos::NUM_OPERATIONS, numOps_Tape());
+  tapestats(TapeInfos::NUM_OPERATIONS, tapeInfos_.opBuffer_.numOnTape());
 
   /* finish constants tape, close it, update stats */
-  if (flag != 0 || val_file()) {
-    if (currVal() != valBuffer()) {
+  if (flag != 0 || tapeInfos_.valBuffer_.file() != nullptr) {
+    if (tapeInfos_.valBuffer_.position() != 0) {
       tapeInfos_.put_block<ValInfo<TapeInfos, ErrorType>>(
-          perTapeInfos_.val_fileName, currVal());
-    }
-    if (val_file()) {
-      fclose(val_file());
-      val_file(nullptr);
+          perTapeInfos_.val_fileName, tapeInfos_.valBuffer_.position());
     }
     tapestats(TapeInfos::VAL_FILE_ACCESS, 1);
-    delete[] valBuffer();
-    valBuffer(nullptr);
+    tapeInfos_.valBuffer_.closeFile();
+    delete[] tapeInfos_.valBuffer_.releaseBuffer();
   } else {
-    numVals_Tape(currVal() - valBuffer());
+    tapeInfos_.valBuffer_.numOnTape(tapeInfos_.valBuffer_.position());
   }
-  tapestats(TapeInfos::NUM_VALUES, numVals_Tape());
+  tapestats(TapeInfos::NUM_VALUES, tapeInfos_.valBuffer_.numOnTape());
 
   /* finish locations tape, update and write tape stats, close tape */
-  if (flag != 0 || (loc_file() != nullptr)) {
-    if (currLoc() != locBuffer()) {
+  if (flag != 0 || (tapeInfos_.locBuffer_.file() != nullptr)) {
+    if (tapeInfos_.locBuffer_.position() != 0) {
       tapeInfos_.put_block<LocInfo<TapeInfos, ErrorType>>(
-          perTapeInfos_.loc_fileName, currLoc());
+          perTapeInfos_.loc_fileName, tapeInfos_.locBuffer_.position());
     }
-    tapestats(TapeInfos::NUM_LOCATIONS, numLocs_Tape());
+    tapestats(TapeInfos::NUM_LOCATIONS, tapeInfos_.locBuffer_.numOnTape());
     tapestats(TapeInfos::LOC_FILE_ACCESS, 1);
     /* write tape stats */
-    fseek(loc_file(), 0, 0);
-    fwrite(&get_adolc_id(), sizeof(ADOLC_ID), 1, loc_file());
+    fseek(tapeInfos_.locBuffer_.file(), 0, 0);
+    fwrite(&get_adolc_id(), sizeof(ADOLC_ID), 1, tapeInfos_.locBuffer_.file());
     fwrite(tapestats().data(), TapeInfos::STAT_SIZE * sizeof(size_t), 1,
-           loc_file());
-    fclose(loc_file());
-    loc_file(nullptr);
-    delete[] locBuffer();
-    locBuffer(nullptr);
+           tapeInfos_.locBuffer_.file());
+    tapeInfos_.locBuffer_.closeFile();
+    delete[] tapeInfos_.locBuffer_.releaseBuffer();
   } else {
-    numLocs_Tape(currLoc() - locBuffer());
-    tapestats(TapeInfos::NUM_LOCATIONS, numLocs_Tape());
+    tapeInfos_.locBuffer_.numOnTape(tapeInfos_.locBuffer_.position());
+    tapestats(TapeInfos::NUM_LOCATIONS, tapeInfos_.locBuffer_.numOnTape());
   }
 }
 
@@ -633,18 +614,9 @@ void ValueTape::read_tape_stats() {
 /* Finish a forward or reverse sweep. */
 /****************************************************************************/
 void ValueTape::end_sweep() {
-  if (op_file()) {
-    fclose(op_file());
-    op_file(nullptr);
-  }
-  if (loc_file()) {
-    fclose(loc_file());
-    loc_file(nullptr);
-  }
-  if (val_file()) {
-    fclose(val_file());
-    val_file(nullptr);
-  }
+  tapeInfos_.opBuffer_.closeFile();
+  tapeInfos_.locBuffer_.closeFile();
+  tapeInfos_.valBuffer_.closeFile();
   workMode(TapeInfos::NO_MODE);
 }
 
@@ -657,32 +629,36 @@ void ValueTape::discard_params_r(void) {
   size_t rsize = 0;
   size_t remain = 0;
   while (ip > 0) {
-    rsize = currVal() - valBuffer();
+    rsize = tapeInfos_.valBuffer_.position();
     rsize = (rsize < ip) ? rsize : ip;
     ip -= rsize;
-    currVal(currVal() - rsize);
+    tapeInfos_.valBuffer_.position(tapeInfos_.valBuffer_.position() - rsize);
     if (ip > 0) {
-      fseek(val_file(),
+      fseek(tapeInfos_.valBuffer_.file(),
             static_cast<long>(sizeof(double) *
-                              (numVals_Tape() - TapeInfos::VAL_BUFFER_SIZE)),
+                              (tapeInfos_.valBuffer_.numOnTape() -
+                               TapeInfos::VAL_BUFFER_SIZE)),
             SEEK_SET);
 
       for (size_t i = 0; i < to_size_t(TapeInfos::VAL_BUFFER_SIZE / chunkSize);
            ++i)
-        if (fread(valBuffer() + i * chunkSize, chunkSize * sizeof(double), 1,
-                  val_file()) != 1)
+        if (fread(tapeInfos_.valBuffer_.begin() + i * chunkSize,
+                  chunkSize * sizeof(double), 1,
+                  tapeInfos_.valBuffer_.file()) != 1)
           ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                            CURRENT_LOCATION);
 
       remain = TapeInfos::VAL_BUFFER_SIZE % chunkSize;
       if (remain != 0)
-        if (fread(valBuffer() + TapeInfos::VAL_BUFFER_SIZE,
-                  remain * sizeof(double), 1, val_file()) != 1)
+        if (fread(tapeInfos_.valBuffer_.begin() + TapeInfos::VAL_BUFFER_SIZE,
+                  remain * sizeof(double), 1,
+                  tapeInfos_.valBuffer_.file()) != 1)
           ADOLCError::fail(ADOLCError::ErrorType::EVAL_VAL_TAPE_READ_FAILED,
                            CURRENT_LOCATION);
 
-      numVals_Tape(numVals_Tape() - TapeInfos::VAL_BUFFER_SIZE);
-      currVal(lastValP1());
+      tapeInfos_.valBuffer_.numOnTape(tapeInfos_.valBuffer_.numOnTape() -
+                                      TapeInfos::VAL_BUFFER_SIZE);
+      tapeInfos_.valBuffer_.position(tapeInfos_.valBuffer_.capacity());
     }
   }
 }


### PR DESCRIPTION
Introduce BufferState class to summarize common state and behavior in TapeInfos.

BufferState is used as RAII type for what was before stored as separate file pointer, pointer-to-first, pointer-to-current, pointer-to-last and a corresponding number-of-elements-stored; for operations values, locations and taylor coefficients. All four are now represented by a corresponding BufferState that handles the file resources, allocations and indices. Additionally, several Buffer write and read patters are summarized. All changes should make the code more robust and readable.